### PR TITLE
Fix comparison function handle NULL values

### DIFF
--- a/src/enclave/Enclave/ExpressionEvaluation.h
+++ b/src/enclave/Enclave/ExpressionEvaluation.h
@@ -107,7 +107,8 @@ template<typename TuixExpr, template<typename T> class Operation>
 flatbuffers::Offset<tuix::Field> eval_binary_comparison(
   flatbuffers::FlatBufferBuilder &builder,
   const tuix::Field *left,
-  const tuix::Field *right) {
+  const tuix::Field *right,
+  bool is_null_asc = true) {
 
   if (left->value_type() != right->value_type()) {
     throw std::runtime_error(
@@ -205,6 +206,18 @@ flatbuffers::Offset<tuix::Field> eval_binary_comparison(
         + std::string(" on ")
         + std::string(tuix::EnumNameFieldUnion(left->value_type())));
     }
+  } else {
+    // This code block handles comparison when at least one value is NULL.
+    // The logic can be summarized as: (note that the != operation implements XOR for boolean values)
+    // If is_null_asc = 1
+    // (x, NULL) = (0, 1) => (1, 0), (NULL, x) => (0, 1), (NULL, NULL) => (0, 0)
+    //
+    // If is_null_asc = 0
+    // (x, NULL) = (0, 1) => (0, 1), (NULL, x) => (1, 0), (NULL, NULL) => (1, 1)
+    
+    bool left_is_null = left->is_null() != is_null_asc;
+    bool right_is_null = right->is_null() != is_null_asc;
+    result = Operation<bool>()(left_is_null, right_is_null);
   }
   // Writing the result invalidates the left and right temporary pointers
   return tuix::CreateField(

--- a/src/enclave/Enclave/ExpressionEvaluation.h
+++ b/src/enclave/Enclave/ExpressionEvaluation.h
@@ -1154,6 +1154,8 @@ public:
       auto a_eval_offset = flatbuffers_copy(sort_order_evaluators[i]->eval(a), builder);
       auto b_eval_offset = flatbuffers_copy(sort_order_evaluators[i]->eval(b), builder);
 
+      // We ignore the result's NULL flag and use only its underlying value for the comparison.
+      // eval_binary_comparison() uses this underlying value to pass the desired information.
       bool a_less_than_b =
         static_cast<const tuix::BooleanField *>(
           flatbuffers::GetTemporaryPointer<tuix::Field>(

--- a/src/enclave/Enclave/Flatbuffers.cpp
+++ b/src/enclave/Enclave/Flatbuffers.cpp
@@ -167,14 +167,14 @@ std::string to_string(const tuix::MapField *f) {
 
 void print(const tuix::Row *in) {
   flatbuffers::uoffset_t num_fields = in->field_values()->size();
-  printf("[");
+  ocall_print_string("[");
   for (flatbuffers::uoffset_t i = 0; i < num_fields; i++) {
     print(in->field_values()->Get(i));
     if (i + 1 < num_fields) {
-      printf(",");
+      ocall_print_string(",");
     }
   }
-  printf("]\n");
+  ocall_print_string("]\n");
 }
 
 void print(const tuix::Field *field) {

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -283,6 +283,17 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     df.sort($"x", $"y").collect
   }
 
+  testAgainstSpark("sort with null values") { securityLevel =>
+    val data : Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
+      if (x % 3 == 0)
+        Tuple1(null.asInstanceOf[Integer])
+      else
+        Tuple1(x.asInstanceOf[Integer])
+    }).toSeq)
+    val df = makeDF(data, securityLevel, "x")
+    df.sort($"x").collect
+  }
+
   testAgainstSpark("join") { securityLevel =>
     val p_data = for (i <- 1 to 16) yield (i, i.toString, i * 10)
     val f_data = for (i <- 1 to 256 - 16) yield (i, (i % 16).toString, i * 10)

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -284,7 +284,7 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
   }
 
   testAgainstSpark("sort with null values") { securityLevel =>
-    val data : Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
+    val data: Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
       if (x % 3 == 0)
         Tuple1(null.asInstanceOf[Integer])
       else


### PR DESCRIPTION
This PR adds a fix to enable comparison with NULL values, which is used by all of the sort-based operators. The previous comparison function returned NULL when either of the input values is NULL, but also left the underlying value of the field to be false. While this null-intolerant behavior is correct for projection, the underlying value is incorrectly used by Opaque’s internal sorting function, which causes a wrong sort ordering when the input data contains NULL values.