### PR TITLE
Fix filter bug

### DIFF
--- a/src/enclave/Enclave/Filter.cpp
+++ b/src/enclave/Enclave/Filter.cpp
@@ -26,7 +26,8 @@ void filter(uint8_t *condition, size_t condition_length,
     }
 
     // If condition_result is NULL, then always return false
-    bool keep_row = static_cast<const tuix::BooleanField *>(condition_result->value())->value() & !condition_result->is_null();
+    bool keep_row = !condition_result->is_null() &&
+      static_cast<const tuix::BooleanField *>(condition_result->value())->value();
     if (keep_row) {
       w.append(row);
     }

--- a/src/enclave/Enclave/Filter.cpp
+++ b/src/enclave/Enclave/Filter.cpp
@@ -24,11 +24,9 @@ void filter(uint8_t *condition, size_t condition_length,
         std::string("Filter expression expected to return BooleanField, instead returned ")
         + std::string(tuix::EnumNameFieldUnion(condition_result->value_type())));
     }
-    if (condition_result->is_null()) {
-      throw std::runtime_error("Filter expression returned null");
-    }
 
-    bool keep_row = static_cast<const tuix::BooleanField *>(condition_result->value())->value();
+    // If condition_result is NULL, then always return false
+    bool keep_row = static_cast<const tuix::BooleanField *>(condition_result->value())->value() & !condition_result->is_null();
     if (keep_row) {
       w.append(row);
     }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -202,6 +202,17 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     df.filter($"x" > lit(10)).collect
   }
 
+  testAgainstSpark("filter with NULLs") { securityLevel =>
+    val data: Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
+      if (x % 3 == 0)
+        Tuple1(null.asInstanceOf[Integer])
+      else
+        Tuple1(x.asInstanceOf[Integer])
+    }).toSeq)
+    val df = makeDF(data, securityLevel, "x")
+    df.filter($"x" > lit(10)).collect.toSet
+  }
+
   testAgainstSpark("select") { securityLevel =>
     val data = for (i <- 0 until 256) yield ("%03d".format(i) * 3, i.toFloat)
     val df = makeDF(data, securityLevel, "str", "x")


### PR DESCRIPTION
This PR fixes a bug in filter, where it throws an error when filtering on a `NULL` value. This changes to behavior to return `false` instead.