### PR TITLE
Add flatbuffers crumb table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,5 +94,3 @@ Makefile
 CMakeCache.txt
 cmake_install.cmake
 CMakeFiles/
-
-opaqueenv

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ Makefile
 CMakeCache.txt
 cmake_install.cmake
 CMakeFiles/
+
+opaqueenv

--- a/src/enclave/Enclave/FlatbuffersWriters.cpp
+++ b/src/enclave/Enclave/FlatbuffersWriters.cpp
@@ -131,7 +131,7 @@ flatbuffers::Offset<tuix::EncryptedBlocks> RowWriter::finish_blocks(std::string 
   std::vector<flatbuffers::Offset<tuix::LogEntry>> curr_log_entry_vector;
   std::vector<flatbuffers::Offset<tuix::LogEntry>> past_log_entries_vector;
   std::vector<int> num_past_log_entries;
-  std::vector<flatbuffers::Offset<tuix::LogEntryChainMac>> log_entry_chain_hash_vector;
+  std::vector<flatbuffers::Offset<tuix::Mac>> log_entry_chain_hash_vector;
   
   if (curr_ecall != std::string("")) {
     // Only write log entry chain if this is the output of an ecall, 
@@ -210,7 +210,7 @@ flatbuffers::Offset<tuix::EncryptedBlocks> RowWriter::finish_blocks(std::string 
     ocall_malloc(OE_HMAC_SIZE, &untrusted_mac);
     std::unique_ptr<uint8_t, decltype(&ocall_free)> mac_ptr(untrusted_mac, &ocall_free);
     memcpy(mac_ptr.get(), hmac, OE_HMAC_SIZE);
-    auto mac_offset = tuix::CreateLogEntryChainMac(enc_block_builder, 
+    auto mac_offset = tuix::CreateMac(enc_block_builder, 
         enc_block_builder.CreateVector(mac_ptr.get(), OE_HMAC_SIZE));
     log_entry_chain_hash_vector.push_back(mac_offset);
 

--- a/src/flatbuffers/EncryptedBlock.fbs
+++ b/src/flatbuffers/EncryptedBlock.fbs
@@ -13,6 +13,7 @@ table EncryptedBlocks {
     blocks:[EncryptedBlock];
     log:LogEntryChain;
     log_mac:[Mac]; 
+    /* all_outputs_mac:[Mac]; */
 }
 
 table SortedRuns {
@@ -20,22 +21,34 @@ table SortedRuns {
 }
 
 table LogEntry {
-    ecall:string;
-    snd_pid:int;
-    rcv_pid:int;
-    job_id:int;
-    num_macs:int;
-    mac_lst:[ubyte];
-    mac_lst_mac:[ubyte];
+    ecall:string; // ecall executed
+    snd_pid:int; // partition where ecall was executed - to be deprecated
+    rcv_pid:int; // partition of subsequent ecall - to be deprecated
+    job_id:int; // Number of ecalls executed in this enclave before this ecall - to be deprecated
+    num_macs:int; // Number of EncryptedBlock's in this EncryptedBlocks - checked during runtime
+    mac_lst:[ubyte]; // List of all MACs. one from each EncryptedBlocks - checked during runtime
+    mac_lst_mac:[ubyte]; // MAC(mac_lst) - checked during runtime
+    /* input_log_macs:[Mac]; // List of all EncryptedBlocks' log_mac's */
 }
 
 table LogEntryChain {
     curr_entries:[LogEntry];
-    past_entries:[LogEntry];
+    past_entries:[LogEntry]; // To be deprecated in favor of the line below
+    // past_entries:[Crumb];
     num_past_entries:[int];
 }
 
 table Mac {
     mac:[ubyte];
 }
+
+// Contains information about an ecall, which will be pieced together during post verfication to verify the DAG
+table Crumb {
+    input_log_macs:[Mac]; // List of all EncryptedBlocks log_mac's
+    all_outputs_mac:Mac; // MAC over all outputs of ecall from which this EncryptedBlocks came from
+    ecall:string; // Ecall executed
+    log_mac:Mac; // MAC over the LogEntryChain from this EncryptedBlocks
+}
+
+
 

--- a/src/flatbuffers/EncryptedBlock.fbs
+++ b/src/flatbuffers/EncryptedBlock.fbs
@@ -12,7 +12,7 @@ table EncryptedBlock {
 table EncryptedBlocks {
     blocks:[EncryptedBlock];
     log:LogEntryChain;
-    log_mac:[LogEntryChainMac]; 
+    log_mac:[Mac]; 
 }
 
 table SortedRuns {
@@ -35,7 +35,7 @@ table LogEntryChain {
     num_past_entries:[int];
 }
 
-table LogEntryChainMac {
+table Mac {
     mac:[ubyte];
 }
 

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -1435,7 +1435,7 @@ object Utils extends Logging {
       tuix.EncryptedBlocks.createLogMacVector(builder, allLogMacs.map { logMac =>
           val mac = new Array[Byte](logMac.macLength)
           logMac.macAsByteBuffer.get(mac)
-          tuix.LogEntryChainMac.createLogEntryChainMac(builder, tuix.LogEntryChainMac.createMacVector(builder, mac))
+          tuix.Mac.createMac(builder, tuix.Mac.createMacVector(builder, mac))
         }.toArray)
       ))
     Block(builder.sizedByteArray())


### PR DESCRIPTION
* Add Flatbuffers "crumb" table, to be used for piecing together the executed DAG during post verification
* Changes Flatbuffers "LogEntryChainMac" to "Mac" for generalization purposes. "Mac" will be used in subsequent changes