### PR TITLE
Changing operator matching from logical to physical

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ concurrentRestrictions in Global := Seq(
 fork in Test := true
 fork in run := true
 
+testOptions in Test += Tests.Argument("-oF")
 javaOptions in Test ++= Seq("-Xmx2048m", "-XX:ReservedCodeCacheSize=384m")
 javaOptions in run ++= Seq(
   "-Xmx2048m", "-XX:ReservedCodeCacheSize=384m", "-Dspark.master=local[1]")

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -74,6 +74,7 @@ import org.apache.spark.sql.catalyst.expressions.Upper
 import org.apache.spark.sql.catalyst.expressions.Year
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.expressions.aggregate.Average
+import org.apache.spark.sql.catalyst.expressions.aggregate.Complete
 import org.apache.spark.sql.catalyst.expressions.aggregate.Count
 import org.apache.spark.sql.catalyst.expressions.aggregate.Final
 import org.apache.spark.sql.catalyst.expressions.aggregate.First
@@ -1136,17 +1137,17 @@ object Utils extends Logging {
   }
 
   def serializeAggOp(
-    groupingExpressions: Seq[Expression],
-    aggExpressions: Seq[NamedExpression],
+    groupingExpressions: Seq[NamedExpression],
+    aggExpressions: Seq[AggregateExpression],
     input: Seq[Attribute]): Array[Byte] = {
     // aggExpressions contains both grouping expressions and AggregateExpressions. Transform the
     // grouping expressions into AggregateExpressions that collect the first seen value.
-    val aggExpressionsWithFirst = aggExpressions.map {
-      case Alias(e: AggregateExpression, _) => e
-      case e: NamedExpression => AggregateExpression(First(e, Literal(false)), Final, false)
+    val aggGroupingExpressions = groupingExpressions.map {
+      case e: NamedExpression => AggregateExpression(First(e, Literal(false)), Complete, false)
     }
+    val aggregateExpressions = aggGroupingExpressions ++ aggExpressions
 
-    val aggSchema = aggExpressionsWithFirst.flatMap(_.aggregateFunction.aggBufferAttributes)
+    val aggSchema = aggExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
     // For aggregation, we concatenate the current aggregate row with the new input row and run
     // the update expressions as a projection to obtain a new aggregate row. concatSchema
     // describes the schema of the temporary concatenated row.
@@ -1161,7 +1162,7 @@ object Utils extends Logging {
           groupingExpressions.map(e => flatbuffersSerializeExpression(builder, e, input)).toArray),
         tuix.AggregateOp.createAggregateExpressionsVector(
           builder,
-          aggExpressionsWithFirst
+          aggregateExpressions
             .map(e => serializeAggExpression(builder, e, input, aggSchema, concatSchema))
             .toArray)))
     builder.sizedByteArray()

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -1140,14 +1140,12 @@ object Utils extends Logging {
     groupingExpressions: Seq[NamedExpression],
     aggExpressions: Seq[AggregateExpression],
     input: Seq[Attribute]): Array[Byte] = {
-    // aggExpressions contains both grouping expressions and AggregateExpressions. Transform the
-    // grouping expressions into AggregateExpressions that collect the first seen value.
     val aggGroupingExpressions = groupingExpressions.map {
       case e: NamedExpression => AggregateExpression(First(e, Literal(false)), Complete, false)
     }
     val aggregateExpressions = aggGroupingExpressions ++ aggExpressions
 
-    val aggSchema = aggExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
+    val aggSchema = aggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
     // For aggregation, we concatenate the current aggregate row with the new input row and run
     // the update expressions as a projection to obtain a new aggregate row. concatSchema
     // describes the schema of the temporary concatenated row.

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/logical/rules.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/logical/rules.scala
@@ -57,53 +57,6 @@ object ConvertToOpaqueOperators extends Rule[LogicalPlan] {
     case l @ LogicalRelation(baseRelation: EncryptedScan, _, _, false) =>
       EncryptedBlockRDD(l.output, baseRelation.buildBlockedScan())
 
-    case p @ Project(projectList, child) if isEncrypted(child) =>
-      EncryptedProject(projectList, child.asInstanceOf[OpaqueOperator])
-
-    // We don't support null values yet, so there's no point in checking whether the output of an
-    // encrypted operator is null
-    case p @ Filter(And(IsNotNull(_), IsNotNull(_)), child) if isEncrypted(child) =>
-      child
-    case p @ Filter(IsNotNull(_), child) if isEncrypted(child) =>
-      child
-
-    case p @ Filter(condition, child) if isEncrypted(child) =>
-      EncryptedFilter(condition, child.asInstanceOf[OpaqueOperator])
-
-    case p @ Sort(order, true, child) if isEncrypted(child) =>
-      EncryptedSort(order, child.asInstanceOf[OpaqueOperator])
-
-    case p @ Join(left, right, joinType, condition, _) if isEncrypted(p) =>
-      EncryptedJoin(
-        left.asInstanceOf[OpaqueOperator], right.asInstanceOf[OpaqueOperator], joinType, condition)
-
-    // case p @ Aggregate(groupingExprs, aggExprs, child) if isEncrypted(p) =>
-    //   UndoCollapseProject.separateProjectAndAgg(p) match {
-    //     case Some((projectExprs, aggExprs)) =>
-    //       EncryptedProject(
-    //         projectExprs,
-    //         EncryptedAggregate(
-    //           groupingExprs, aggExprs,
-    //           EncryptedSort(
-    //             groupingExprs.map(e => SortOrder(e, Ascending)),
-    //             child.asInstanceOf[OpaqueOperator])))
-    //     case None =>
-    //       EncryptedAggregate(
-    //         groupingExprs, aggExprs,
-    //         EncryptedSort(
-    //           groupingExprs.map(e => SortOrder(e, Ascending)),
-    //           child.asInstanceOf[OpaqueOperator]))
-    //   }
-
-    case p @ Union(Seq(left, right)) if isEncrypted(p) =>
-      EncryptedUnion(left.asInstanceOf[OpaqueOperator], right.asInstanceOf[OpaqueOperator])
-
-    case p @ LocalLimit(limitExpr, child) if isEncrypted(p) =>
-      EncryptedLocalLimit(limitExpr, child.asInstanceOf[OpaqueOperator])
-
-    case p @ GlobalLimit(limitExpr, child) if isEncrypted(p) =>
-      EncryptedGlobalLimit(limitExpr, child.asInstanceOf[OpaqueOperator])
-
     case InMemoryRelationMatcher(output, storageLevel, child) if isEncrypted(child) =>
       EncryptedBlockRDD(
         output,

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/logical/rules.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/logical/rules.scala
@@ -77,23 +77,23 @@ object ConvertToOpaqueOperators extends Rule[LogicalPlan] {
       EncryptedJoin(
         left.asInstanceOf[OpaqueOperator], right.asInstanceOf[OpaqueOperator], joinType, condition)
 
-    case p @ Aggregate(groupingExprs, aggExprs, child) if isEncrypted(p) =>
-      UndoCollapseProject.separateProjectAndAgg(p) match {
-        case Some((projectExprs, aggExprs)) =>
-          EncryptedProject(
-            projectExprs,
-            EncryptedAggregate(
-              groupingExprs, aggExprs,
-              EncryptedSort(
-                groupingExprs.map(e => SortOrder(e, Ascending)),
-                child.asInstanceOf[OpaqueOperator])))
-        case None =>
-          EncryptedAggregate(
-            groupingExprs, aggExprs,
-            EncryptedSort(
-              groupingExprs.map(e => SortOrder(e, Ascending)),
-              child.asInstanceOf[OpaqueOperator]))
-      }
+    // case p @ Aggregate(groupingExprs, aggExprs, child) if isEncrypted(p) =>
+    //   UndoCollapseProject.separateProjectAndAgg(p) match {
+    //     case Some((projectExprs, aggExprs)) =>
+    //       EncryptedProject(
+    //         projectExprs,
+    //         EncryptedAggregate(
+    //           groupingExprs, aggExprs,
+    //           EncryptedSort(
+    //             groupingExprs.map(e => SortOrder(e, Ascending)),
+    //             child.asInstanceOf[OpaqueOperator])))
+    //     case None =>
+    //       EncryptedAggregate(
+    //         groupingExprs, aggExprs,
+    //         EncryptedSort(
+    //           groupingExprs.map(e => SortOrder(e, Ascending)),
+    //           child.asInstanceOf[OpaqueOperator]))
+    //   }
 
     case p @ Union(Seq(left, right)) if isEncrypted(p) =>
       EncryptedUnion(left.asInstanceOf[OpaqueOperator], right.asInstanceOf[OpaqueOperator])

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
@@ -19,19 +19,19 @@ package edu.berkeley.cs.rise.opaque
 
 import org.apache.spark.sql.Strategy
 import org.apache.spark.sql.catalyst.expressions.Alias
+import org.apache.spark.sql.catalyst.expressions.And
 import org.apache.spark.sql.catalyst.expressions.Ascending
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.IntegerLiteral
+import org.apache.spark.sql.catalyst.expressions.IsNotNull
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
 import org.apache.spark.sql.catalyst.planning.PhysicalAggregation
-import org.apache.spark.sql.catalyst.plans.logical.Join
-import org.apache.spark.sql.catalyst.plans.logical.JoinHint
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.SparkPlan
 
 import edu.berkeley.cs.rise.opaque.execution._
@@ -54,62 +54,85 @@ object OpaqueOperators extends Strategy {
   }
 
   def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
-    case EncryptedProject(projectList, child) =>
+    case Project(projectList, child) if isEncrypted(child) =>
       EncryptedProjectExec(projectList, planLater(child)) :: Nil
 
-    case EncryptedFilter(condition, child) =>
+    // We don't support null values yet, so there's no point in checking whether the output of an
+    // encrypted operator is null
+    case p @ Filter(And(IsNotNull(_), IsNotNull(_)), child) if isEncrypted(child) =>
+      planLater(child) :: Nil
+    case p @ Filter(IsNotNull(_), child) if isEncrypted(child) =>
+      planLater(child) :: Nil
+
+    case Filter(condition, child) if isEncrypted(child) =>
       EncryptedFilterExec(condition, planLater(child)) :: Nil
 
-    case EncryptedSort(order, child) =>
-      EncryptedSortExec(order, planLater(child)) :: Nil
+    case Sort(sortExprs, global, child) if isEncrypted(child) =>
+      EncryptedSortExec(sortExprs, planLater(child)) :: Nil
 
-    case EncryptedJoin(left, right, joinType, condition) =>
-      Join(left, right, joinType, condition, JoinHint.NONE) match {
-        case ExtractEquiJoinKeys(_, leftKeys, rightKeys, condition, _, _, _) =>
-          val (leftProjSchema, leftKeysProj, tag) = tagForJoin(leftKeys, left.output, true)
-          val (rightProjSchema, rightKeysProj, _) = tagForJoin(rightKeys, right.output, false)
-          val leftProj = EncryptedProjectExec(leftProjSchema, planLater(left))
-          val rightProj = EncryptedProjectExec(rightProjSchema, planLater(right))
-          val unioned = EncryptedUnionExec(leftProj, rightProj)
-          val sorted = EncryptedSortExec(sortForJoin(leftKeysProj, tag, unioned.output), unioned)
-          val joined = EncryptedSortMergeJoinExec(
-            joinType,
-            leftKeysProj,
-            rightKeysProj,
-            leftProjSchema.map(_.toAttribute),
-            rightProjSchema.map(_.toAttribute),
-            (leftProjSchema ++ rightProjSchema).map(_.toAttribute),
-            sorted)
-          val tagsDropped = EncryptedProjectExec(dropTags(left.output, right.output), joined)
-          val filtered = condition match {
-            case Some(condition) => EncryptedFilterExec(condition, tagsDropped)
-            case None => tagsDropped
-          }
-          filtered :: Nil
-        case _ => Nil
+    case p @ ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, condition, left, right, _) if isEncrypted(p) =>
+      val (leftProjSchema, leftKeysProj, tag) = tagForJoin(leftKeys, left.output, true)
+      val (rightProjSchema, rightKeysProj, _) = tagForJoin(rightKeys, right.output, false)
+      val leftProj = EncryptedProjectExec(leftProjSchema, planLater(left))
+      val rightProj = EncryptedProjectExec(rightProjSchema, planLater(right))
+      val unioned = EncryptedUnionExec(leftProj, rightProj)
+      val sorted = EncryptedSortExec(sortForJoin(leftKeysProj, tag, unioned.output), unioned)
+      val joined = EncryptedSortMergeJoinExec(
+        joinType,
+        leftKeysProj,
+        rightKeysProj,
+        leftProjSchema.map(_.toAttribute),
+        rightProjSchema.map(_.toAttribute),
+        (leftProjSchema ++ rightProjSchema).map(_.toAttribute),
+        sorted)
+      val tagsDropped = EncryptedProjectExec(dropTags(left.output, right.output), joined)
+      val filtered = condition match {
+        case Some(condition) => EncryptedFilterExec(condition, tagsDropped)
+        case None => tagsDropped
       }
+      filtered :: Nil
 
     case a @ PhysicalAggregation(groupingExpressions, aggExpressions, resultExpressions, child)
         if (isEncrypted(child) && aggExpressions.forall(expr => expr.isInstanceOf[AggregateExpression])) =>
-
       val aggregateExpressions = aggExpressions.map(expr => expr.asInstanceOf[AggregateExpression]).map(_.copy(mode = Complete))
 
-      println(s"groupingExpressions: $groupingExpressions")
-      println(s"aggregateExpressions: ${aggregateExpressions.map(_.resultAttribute)}")
-      println(s"resultExpressions: $resultExpressions")
+      EncryptedProjectExec(resultExpressions,
+        EncryptedAggregateExec(
+          groupingExpressions, aggregateExpressions,
+          EncryptedSortExec(
+            groupingExpressions.map(e => SortOrder(e, Ascending)), planLater(child)))) :: Nil
 
-      EncryptedAggregateExec(
-        groupingExpressions, aggregateExpressions,
-        EncryptedSortExec(
-          groupingExpressions.map(e => SortOrder(e, Ascending)), planLater(child))) :: Nil
-
-    case EncryptedUnion(left, right) =>
+    case p @ Union(Seq(left, right)) if isEncrypted(p) =>
       EncryptedUnionExec(planLater(left), planLater(right)) :: Nil
 
-    case EncryptedLocalLimit(IntegerLiteral(limit), child) =>
+    case ReturnAnswer(rootPlan) => rootPlan match {
+      case Limit(IntegerLiteral(limit), Sort(sortExprs, true, child)) if isEncrypted(child) =>
+      EncryptedGlobalLimitExec(limit,
+        EncryptedLocalLimitExec(limit,
+          EncryptedSortExec(sortExprs, planLater(child)))) :: Nil
+
+      case Limit(IntegerLiteral(limit), Project(projectList, child)) if isEncrypted(child) =>
+        EncryptedGlobalLimitExec(limit,
+          EncryptedLocalLimitExec(limit,
+            EncryptedProjectExec(projectList, planLater(child)))) :: Nil
+
+      case _ => Nil
+    }
+
+    case Limit(IntegerLiteral(limit), Sort(sortExprs, true, child)) if isEncrypted(child) =>
+      EncryptedGlobalLimitExec(limit,
+        EncryptedLocalLimitExec(limit,
+          EncryptedSortExec(sortExprs, planLater(child)))) :: Nil
+
+    case Limit(IntegerLiteral(limit), Project(projectList, child)) if isEncrypted(child) =>
+      EncryptedGlobalLimitExec(limit,
+        EncryptedLocalLimitExec(limit,
+          EncryptedProjectExec(projectList, planLater(child)))) :: Nil
+
+    case LocalLimit(IntegerLiteral(limit), child) if isEncrypted(child) =>
       EncryptedLocalLimitExec(limit, planLater(child)) :: Nil
 
-    case EncryptedGlobalLimit(IntegerLiteral(limit), child) =>
+    case GlobalLimit(IntegerLiteral(limit), child) if isEncrypted(child) =>
       EncryptedGlobalLimitExec(limit, planLater(child)) :: Nil
 
     case Encrypt(child) =>

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
@@ -26,7 +26,9 @@ import org.apache.spark.sql.catalyst.expressions.IntegerLiteral
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.expressions.SortOrder
+import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
+import org.apache.spark.sql.catalyst.planning.PhysicalAggregation
 import org.apache.spark.sql.catalyst.plans.logical.Join
 import org.apache.spark.sql.catalyst.plans.logical.JoinHint
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -36,6 +38,21 @@ import edu.berkeley.cs.rise.opaque.execution._
 import edu.berkeley.cs.rise.opaque.logical._
 
 object OpaqueOperators extends Strategy {
+
+  def isEncrypted(plan: LogicalPlan): Boolean = {
+    plan.find {
+      case _: OpaqueOperator => true
+      case _ => false
+    }.nonEmpty
+  }
+
+  def isEncrypted(plan: SparkPlan): Boolean = {
+    plan.find {
+      case _: OpaqueOperatorExec => true
+      case _ => false
+    }.nonEmpty
+  }
+
   def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case EncryptedProject(projectList, child) =>
       EncryptedProjectExec(projectList, planLater(child)) :: Nil
@@ -72,8 +89,19 @@ object OpaqueOperators extends Strategy {
         case _ => Nil
       }
 
-    case a @ EncryptedAggregate(groupingExpressions, aggExpressions, child) =>
-      EncryptedAggregateExec(groupingExpressions, aggExpressions, planLater(child)) :: Nil
+    case a @ PhysicalAggregation(groupingExpressions, aggExpressions, resultExpressions, child)
+        if (isEncrypted(child) && aggExpressions.forall(expr => expr.isInstanceOf[AggregateExpression])) =>
+
+      val aggregateExpressions = aggExpressions.map(expr => expr.asInstanceOf[AggregateExpression]).map(_.copy(mode = Complete))
+
+      println(s"groupingExpressions: $groupingExpressions")
+      println(s"aggregateExpressions: ${aggregateExpressions.map(_.resultAttribute)}")
+      println(s"resultExpressions: $resultExpressions")
+
+      EncryptedAggregateExec(
+        groupingExpressions, aggregateExpressions,
+        EncryptedSortExec(
+          groupingExpressions.map(e => SortOrder(e, Ascending)), planLater(child))) :: Nil
 
     case EncryptedUnion(left, right) =>
       EncryptedUnionExec(planLater(left), planLater(right)) :: Nil

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -122,212 +122,212 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     }
   }
 
-  testAgainstSpark("create DataFrame from sequence") { securityLevel =>
-    val data = for (i <- 0 until 5) yield ("foo", i)
-    makeDF(data, securityLevel, "word", "count").collect
-  }
+  // testAgainstSpark("create DataFrame from sequence") { securityLevel =>
+  //   val data = for (i <- 0 until 5) yield ("foo", i)
+  //   makeDF(data, securityLevel, "word", "count").collect
+  // }
 
-  testAgainstSpark("create DataFrame with BinaryType + ByteType") { securityLevel =>
-    val data: Seq[(Array[Byte], Byte)] =
-      Seq((Array[Byte](0.toByte, -128.toByte, 127.toByte), 42.toByte))
-    makeDF(data, securityLevel, "BinaryType", "ByteType").collect
-  }
+  // testAgainstSpark("create DataFrame with BinaryType + ByteType") { securityLevel =>
+  //   val data: Seq[(Array[Byte], Byte)] =
+  //     Seq((Array[Byte](0.toByte, -128.toByte, 127.toByte), 42.toByte))
+  //   makeDF(data, securityLevel, "BinaryType", "ByteType").collect
+  // }
 
-  testAgainstSpark("create DataFrame with CalendarIntervalType + NullType") { securityLevel =>
-    val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 1, 12345), 0.toByte))
-    val schema = StructType(Seq(
-      StructField("CalendarIntervalType", CalendarIntervalType),
-      StructField("NullType", NullType)))
+  // testAgainstSpark("create DataFrame with CalendarIntervalType + NullType") { securityLevel =>
+  //   val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 1, 12345), 0.toByte))
+  //   val schema = StructType(Seq(
+  //     StructField("CalendarIntervalType", CalendarIntervalType),
+  //     StructField("NullType", NullType)))
 
-    securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema)).collect
-  }
+  //   securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema)).collect
+  // }
 
-  testAgainstSpark("create DataFrame with ShortType + TimestampType") { securityLevel =>
-    val data: Seq[(Short, Timestamp)] = Seq((13.toShort, Timestamp.valueOf("2017-12-02 03:04:00")))
-    makeDF(data, securityLevel, "ShortType", "TimestampType").collect
-  }
+  // testAgainstSpark("create DataFrame with ShortType + TimestampType") { securityLevel =>
+  //   val data: Seq[(Short, Timestamp)] = Seq((13.toShort, Timestamp.valueOf("2017-12-02 03:04:00")))
+  //   makeDF(data, securityLevel, "ShortType", "TimestampType").collect
+  // }
 
-  testAgainstSpark("create DataFrame with ArrayType") { securityLevel =>
-    val array: Array[Int] = Array(0, -128, 127, 1)
-    val data = Seq(
-      (array, "dog"),
-      (array, "cat"),
-      (array, "ant"))
-    val df = makeDF(data, securityLevel, "array", "string")
-    df.collect
-  }
+  // testAgainstSpark("create DataFrame with ArrayType") { securityLevel =>
+  //   val array: Array[Int] = Array(0, -128, 127, 1)
+  //   val data = Seq(
+  //     (array, "dog"),
+  //     (array, "cat"),
+  //     (array, "ant"))
+  //   val df = makeDF(data, securityLevel, "array", "string")
+  //   df.collect
+  // }
 
-  testAgainstSpark("create DataFrame with MapType") { securityLevel =>
-    val map: Map[String, Int] = Map("x" -> 24, "y" -> 25, "z" -> 26)
-    val data = Seq(
-      (map, "dog"),
-      (map, "cat"),
-      (map, "ant"))
-    val df = makeDF(data, securityLevel, "map", "string")
-    df.collect
-  }
+  // testAgainstSpark("create DataFrame with MapType") { securityLevel =>
+  //   val map: Map[String, Int] = Map("x" -> 24, "y" -> 25, "z" -> 26)
+  //   val data = Seq(
+  //     (map, "dog"),
+  //     (map, "cat"),
+  //     (map, "ant"))
+  //   val df = makeDF(data, securityLevel, "map", "string")
+  //   df.collect
+  // }
 
-  testAgainstSpark("create DataFrame with nulls for all types") { securityLevel =>
-    val schema = StructType(Seq(
-      StructField("boolean", BooleanType),
-      StructField("integer", IntegerType),
-      StructField("long", LongType),
-      StructField("float", FloatType),
-      StructField("double", DoubleType),
-      StructField("date", DateType),
-      StructField("binary", BinaryType),
-      StructField("byte", ByteType),
-      StructField("calendar_interval", CalendarIntervalType),
-      StructField("null", NullType),
-      StructField("short", ShortType),
-      StructField("timestamp", TimestampType),
-      StructField("array_of_int", DataTypes.createArrayType(IntegerType)),
-      StructField("map_int_to_int", DataTypes.createMapType(IntegerType, IntegerType)),
-      StructField("string", StringType)))
+  // testAgainstSpark("create DataFrame with nulls for all types") { securityLevel =>
+  //   val schema = StructType(Seq(
+  //     StructField("boolean", BooleanType),
+  //     StructField("integer", IntegerType),
+  //     StructField("long", LongType),
+  //     StructField("float", FloatType),
+  //     StructField("double", DoubleType),
+  //     StructField("date", DateType),
+  //     StructField("binary", BinaryType),
+  //     StructField("byte", ByteType),
+  //     StructField("calendar_interval", CalendarIntervalType),
+  //     StructField("null", NullType),
+  //     StructField("short", ShortType),
+  //     StructField("timestamp", TimestampType),
+  //     StructField("array_of_int", DataTypes.createArrayType(IntegerType)),
+  //     StructField("map_int_to_int", DataTypes.createMapType(IntegerType, IntegerType)),
+  //     StructField("string", StringType)))
 
-    securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(Seq(Row.fromSeq(Seq.fill(schema.length) { null })), numPartitions),
-        schema)).collect
-  }
+  //   securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(Seq(Row.fromSeq(Seq.fill(schema.length) { null })), numPartitions),
+  //       schema)).collect
+  // }
 
-  testAgainstSpark("filter") { securityLevel =>
-    val df = makeDF(
-      (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
-      securityLevel,
-      "a", "b", "c", "d", "x")
-    df.filter($"x" > lit(10)).collect
-  }
+  // testAgainstSpark("filter") { securityLevel =>
+  //   val df = makeDF(
+  //     (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
+  //     securityLevel,
+  //     "a", "b", "c", "d", "x")
+  //   df.filter($"x" > lit(10)).collect
+  // }
 
-  testAgainstSpark("filter with NULLs") { securityLevel =>
-    val data: Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
-      if (x % 3 == 0)
-        Tuple1(null.asInstanceOf[Integer])
-      else
-        Tuple1(x.asInstanceOf[Integer])
-    }).toSeq)
-    val df = makeDF(data, securityLevel, "x")
-    df.filter($"x" > lit(10)).collect.toSet
-  }
+  // testAgainstSpark("filter with NULLs") { securityLevel =>
+  //   val data: Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
+  //     if (x % 3 == 0)
+  //       Tuple1(null.asInstanceOf[Integer])
+  //     else
+  //       Tuple1(x.asInstanceOf[Integer])
+  //   }).toSeq)
+  //   val df = makeDF(data, securityLevel, "x")
+  //   df.filter($"x" > lit(10)).collect.toSet
+  // }
 
-  testAgainstSpark("select") { securityLevel =>
-    val data = for (i <- 0 until 256) yield ("%03d".format(i) * 3, i.toFloat)
-    val df = makeDF(data, securityLevel, "str", "x")
-    df.select($"str").collect
-  }
+  // testAgainstSpark("select") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield ("%03d".format(i) * 3, i.toFloat)
+  //   val df = makeDF(data, securityLevel, "str", "x")
+  //   df.select($"str").collect
+  // }
 
-  testAgainstSpark("select with expressions") { securityLevel =>
-    val df = makeDF(
-      (1 to 20).map(x => (true, "hello world!", 1.0, 2.0f, x)),
-      securityLevel,
-      "a", "b", "c", "d", "x")
-    df.select(
-      $"x" + $"x" * $"x" - $"x",
-      substring($"b", 5, 20),
-      $"x" > $"x",
-      $"x" >= $"x",
-      $"x" <= $"x").collect.toSet
-  }
+  // testAgainstSpark("select with expressions") { securityLevel =>
+  //   val df = makeDF(
+  //     (1 to 20).map(x => (true, "hello world!", 1.0, 2.0f, x)),
+  //     securityLevel,
+  //     "a", "b", "c", "d", "x")
+  //   df.select(
+  //     $"x" + $"x" * $"x" - $"x",
+  //     substring($"b", 5, 20),
+  //     $"x" > $"x",
+  //     $"x" >= $"x",
+  //     $"x" <= $"x").collect.toSet
+  // }
 
-  testAgainstSpark("union") { securityLevel =>
-    val df1 = makeDF(
-      (1 to 20).map(x => (x, x.toString)).reverse,
-      securityLevel,
-      "a", "b")
-    val df2 = makeDF(
-      (1 to 20).map(x => (x, (x + 1).toString)),
-      securityLevel,
-      "a", "b")
-    df1.union(df2).collect.toSet
-  }
+  // testAgainstSpark("union") { securityLevel =>
+  //   val df1 = makeDF(
+  //     (1 to 20).map(x => (x, x.toString)).reverse,
+  //     securityLevel,
+  //     "a", "b")
+  //   val df2 = makeDF(
+  //     (1 to 20).map(x => (x, (x + 1).toString)),
+  //     securityLevel,
+  //     "a", "b")
+  //   df1.union(df2).collect.toSet
+  // }
 
-  testOpaqueOnly("cache") { securityLevel =>
-    def numCached(ds: Dataset[_]): Int =
-      ds.queryExecution.executedPlan.collect {
-        case cached: EncryptedBlockRDDScanExec
-            if cached.rdd.getStorageLevel != StorageLevel.NONE =>
-          cached
-      }.size
+  // testOpaqueOnly("cache") { securityLevel =>
+  //   def numCached(ds: Dataset[_]): Int =
+  //     ds.queryExecution.executedPlan.collect {
+  //       case cached: EncryptedBlockRDDScanExec
+  //           if cached.rdd.getStorageLevel != StorageLevel.NONE =>
+  //         cached
+  //     }.size
 
-    val data = List((1, 3), (1, 4), (1, 5), (2, 4))
-    val df = makeDF(data, securityLevel, "a", "b").cache()
+  //   val data = List((1, 3), (1, 4), (1, 5), (2, 4))
+  //   val df = makeDF(data, securityLevel, "a", "b").cache()
 
-    val agg = df.groupBy($"a").agg(sum("b"))
+  //   val agg = df.groupBy($"a").agg(sum("b"))
 
-    assert(numCached(agg) === 1)
+  //   assert(numCached(agg) === 1)
 
-    val expected = data.groupBy(_._1).mapValues(_.map(_._2).sum)
-    assert(agg.collect.toSet === expected.map(Row.fromTuple).toSet)
-    df.unpersist()
-  }
+  //   val expected = data.groupBy(_._1).mapValues(_.map(_._2).sum)
+  //   assert(agg.collect.toSet === expected.map(Row.fromTuple).toSet)
+  //   df.unpersist()
+  // }
 
-  testAgainstSpark("sort") { securityLevel =>
-    val data = Random.shuffle((0 until 256).map(x => (x.toString, x)).toSeq)
-    val df = makeDF(data, securityLevel, "str", "x")
-    df.sort($"x").collect
-  }
+  // testAgainstSpark("sort") { securityLevel =>
+  //   val data = Random.shuffle((0 until 256).map(x => (x.toString, x)).toSeq)
+  //   val df = makeDF(data, securityLevel, "str", "x")
+  //   df.sort($"x").collect
+  // }
 
-  testAgainstSpark("sort zero elements") { securityLevel =>
-    val data = Seq.empty[(String, Int)]
-    val df = makeDF(data, securityLevel, "str", "x")
-    df.sort($"x").collect
-  }
+  // testAgainstSpark("sort zero elements") { securityLevel =>
+  //   val data = Seq.empty[(String, Int)]
+  //   val df = makeDF(data, securityLevel, "str", "x")
+  //   df.sort($"x").collect
+  // }
 
-  testAgainstSpark("sort by float") { securityLevel =>
-    val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
-    val df = makeDF(data, securityLevel, "str", "x")
-    df.sort($"x").collect
-  }
+  // testAgainstSpark("sort by float") { securityLevel =>
+  //   val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
+  //   val df = makeDF(data, securityLevel, "str", "x")
+  //   df.sort($"x").collect
+  // }
 
-  testAgainstSpark("sort by string") { securityLevel =>
-    val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
-    val df = makeDF(data, securityLevel, "str", "x")
-    df.sort($"str").collect
-  }
+  // testAgainstSpark("sort by string") { securityLevel =>
+  //   val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
+  //   val df = makeDF(data, securityLevel, "str", "x")
+  //   df.sort($"str").collect
+  // }
 
-  testAgainstSpark("sort by 2 columns") { securityLevel =>
-    val data = Random.shuffle((0 until 256).map(x => (x / 16, x)).toSeq)
-    val df = makeDF(data, securityLevel, "x", "y")
-    df.sort($"x", $"y").collect
-  }
+  // testAgainstSpark("sort by 2 columns") { securityLevel =>
+  //   val data = Random.shuffle((0 until 256).map(x => (x / 16, x)).toSeq)
+  //   val df = makeDF(data, securityLevel, "x", "y")
+  //   df.sort($"x", $"y").collect
+  // }
 
-  testAgainstSpark("sort with null values") { securityLevel =>
-    val data: Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
-      if (x % 3 == 0)
-        Tuple1(null.asInstanceOf[Integer])
-      else
-        Tuple1(x.asInstanceOf[Integer])
-    }).toSeq)
-    val df = makeDF(data, securityLevel, "x")
-    df.sort($"x").collect
-  }
+  // testAgainstSpark("sort with null values") { securityLevel =>
+  //   val data: Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
+  //     if (x % 3 == 0)
+  //       Tuple1(null.asInstanceOf[Integer])
+  //     else
+  //       Tuple1(x.asInstanceOf[Integer])
+  //   }).toSeq)
+  //   val df = makeDF(data, securityLevel, "x")
+  //   df.sort($"x").collect
+  // }
 
-  testAgainstSpark("join") { securityLevel =>
-    val p_data = for (i <- 1 to 16) yield (i, i.toString, i * 10)
-    val f_data = for (i <- 1 to 256 - 16) yield (i, (i % 16).toString, i * 10)
-    val p = makeDF(p_data, securityLevel, "id", "pk", "x")
-    val f = makeDF(f_data, securityLevel, "id", "fk", "x")
-    p.join(f, $"pk" === $"fk").collect.toSet
-  }
+  // testAgainstSpark("join") { securityLevel =>
+  //   val p_data = for (i <- 1 to 16) yield (i, i.toString, i * 10)
+  //   val f_data = for (i <- 1 to 256 - 16) yield (i, (i % 16).toString, i * 10)
+  //   val p = makeDF(p_data, securityLevel, "id", "pk", "x")
+  //   val f = makeDF(f_data, securityLevel, "id", "fk", "x")
+  //   p.join(f, $"pk" === $"fk").collect.toSet
+  // }
 
-  testAgainstSpark("join on column 1") { securityLevel =>
-    val p_data = for (i <- 1 to 16) yield (i.toString, i * 10)
-    val f_data = for (i <- 1 to 256 - 16) yield ((i % 16).toString, (i * 10).toString, i.toFloat)
-    val p = makeDF(p_data, securityLevel, "pk", "x")
-    val f = makeDF(f_data, securityLevel, "fk", "x", "y")
-    p.join(f, $"pk" === $"fk").collect.toSet
-  }
+  // testAgainstSpark("join on column 1") { securityLevel =>
+  //   val p_data = for (i <- 1 to 16) yield (i.toString, i * 10)
+  //   val f_data = for (i <- 1 to 256 - 16) yield ((i % 16).toString, (i * 10).toString, i.toFloat)
+  //   val p = makeDF(p_data, securityLevel, "pk", "x")
+  //   val f = makeDF(f_data, securityLevel, "fk", "x", "y")
+  //   p.join(f, $"pk" === $"fk").collect.toSet
+  // }
 
-  testAgainstSpark("non-foreign-key join") { securityLevel =>
-    val p_data = for (i <- 1 to 128) yield (i, (i % 16).toString, i * 10)
-    val f_data = for (i <- 1 to 256 - 128) yield (i, (i % 16).toString, i * 10)
-    val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
-    val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
-    p.join(f, $"join_col_1" === $"join_col_2").collect.toSet
-  }
+  // testAgainstSpark("non-foreign-key join") { securityLevel =>
+  //   val p_data = for (i <- 1 to 128) yield (i, (i % 16).toString, i * 10)
+  //   val f_data = for (i <- 1 to 256 - 128) yield (i, (i % 16).toString, i * 10)
+  //   val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
+  //   val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
+  //   p.join(f, $"join_col_1" === $"join_col_2").collect.toSet
+  // }
 
   def abc(i: Int): String = (i % 3) match {
     case 0 => "A"
@@ -339,463 +339,465 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     val data = for (i <- 0 until 256) yield (i, abc(i), i.toDouble)
     val words = makeDF(data, securityLevel, "id", "category", "price")
 
-    words.groupBy("category").agg(avg("price").as("avgPrice"))
+    val result = words.groupBy("category").agg(avg("price"))
+    result.explain()
+    result
       .collect.sortBy { case Row(category: String, _) => category }
   }
 
-  testAgainstSpark("aggregate count") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "category", "price")
-
-    words.groupBy("category").agg(count("category").as("itemsInCategory"))
-      .collect.sortBy { case Row(category: String, _) => category }
-  }
-
-  testAgainstSpark("aggregate first") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "category", "price")
-
-    words.groupBy("category").agg(first("category").as("firstInCategory"))
-      .collect.sortBy { case Row(category: String, _) => category }
-  }
-
-  testAgainstSpark("aggregate last") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "category", "price")
-
-    words.groupBy("category").agg(last("category").as("lastInCategory"))
-      .collect.sortBy { case Row(category: String, _) => category }
-  }
-
-  testAgainstSpark("aggregate max") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "category", "price")
-
-    words.groupBy("category").agg(max("price").as("maxPrice"))
-      .collect.sortBy { case Row(category: String, _) => category }
-  }
-
-  testAgainstSpark("aggregate min") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "category", "price")
-
-    words.groupBy("category").agg(min("price").as("minPrice"))
-      .collect.sortBy { case Row(category: String, _) => category }
-  }
-
-  testAgainstSpark("aggregate sum") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "word", "count")
-
-    words.groupBy("word").agg(sum("count").as("totalCount"))
-      .collect.sortBy { case Row(word: String, _) => word }
-  }
-
-  testAgainstSpark("aggregate on multiple columns") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (abc(i), 1, 1.0f)
-    val words = makeDF(data, securityLevel, "str", "x", "y")
-
-    words.groupBy("str").agg(sum("y").as("totalY"), avg("x").as("avgX"))
-      .collect.sortBy { case Row(str: String, _, _) => str }
-  }
-
-  testAgainstSpark("global aggregate") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val words = makeDF(data, securityLevel, "id", "word", "count")
-    words.agg(sum("count").as("totalCount")).collect
-  }
-
-  testAgainstSpark("contains") { securityLevel =>
-    val data = for (i <- 0 until 256) yield(i.toString, abc(i))
-    val df = makeDF(data, securityLevel, "word", "abc")
-    df.filter($"word".contains(lit("1"))).collect
-  }
-
-  testAgainstSpark("between") { securityLevel =>
-    val data = for (i <- 0 until 256) yield(i.toString, i)
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.filter($"count".between(50, 150)).collect
-  }
-
-  testAgainstSpark("year") { securityLevel =>
-    val data = Seq(Tuple2(1, new java.sql.Date(new java.util.Date().getTime())))
-    val df = makeDF(data, securityLevel, "id", "date")
-    df.select(year($"date")).collect
-  }
-
-  testAgainstSpark("case when - 1 branch with else (string)") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.select(when(df("word") === "foo", "hi").otherwise("bye")).collect
-  }
-
-  testAgainstSpark("case when - 1 branch with else (int)") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.select(when(df("word") === "foo", 10).otherwise(30)).collect
-  }
-
-  testAgainstSpark("case when - 1 branch without else (string)") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.select(when(df("word") === "foo", "hi")).collect
-  }
-
-  testAgainstSpark("case when - 1 branch without else (int)") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.select(when(df("word") === "foo", 10)).collect 
-  }
-
-  testAgainstSpark("case when - 2 branch with else (string)") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.select(when(df("word") === "foo", "hi").when(df("word") === "baz", "hello").otherwise("bye")).collect
-  }
-
-  testAgainstSpark("case when - 2 branch with else (int)") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.select(when(df("word") === "foo", 10).when(df("word") === "baz", 20).otherwise(30)).collect
-  }
-
-  testAgainstSpark("case when - 2 branch without else (string)") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.select(when(df("word") === "foo", "hi").when(df("word") === "baz", "hello")).collect 
-  }
-
-  testAgainstSpark("case when - 2 branch without else (int)") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.select(when(df("word") === "foo", 3).when(df("word") === "baz", 2)).collect
-  }
-
-  testAgainstSpark("LIKE - Contains") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.filter($"word".like("%a%")).collect
-  } 
-
-  testAgainstSpark("LIKE - StartsWith") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.filter($"word".like("ba%")).collect
-  } 
-
-  testAgainstSpark("LIKE - EndsWith") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.filter($"word".like("%ar")).collect
-  }
-
-  testAgainstSpark("LIKE - Empty Pattern") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.filter($"word".like("")).collect
-  }
-
-  testAgainstSpark("LIKE - Match All") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.filter($"word".like("%")).collect
-  }
-
-  testAgainstSpark("LIKE - Single Wildcard") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.filter($"word".like("ba_")).collect
-  }
-
-  testAgainstSpark("LIKE - SQL API") { securityLevel =>
-    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-    val df = makeDF(data, securityLevel, "word", "count")
-    df.createTempView("df")
-    try {
-      spark.sql(""" SELECT word FROM df WHERE word LIKE '_a_' """).collect
-    } finally {
-      spark.catalog.dropTempView("df")
-    }
-  }
-
-  testOpaqueOnly("save and load with explicit schema") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val df = makeDF(data, securityLevel, "id", "word", "count")
-    val path = Utils.createTempDir()
-    path.delete()
-    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
-    try {
-      val df2 = spark.read
-        .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
-        .schema(df.schema)
-        .load(path.toString)
-      assert(df.collect.toSet === df2.collect.toSet)
-      assert(df.groupBy("word").agg(sum("count")).collect.toSet
-        === df2.groupBy("word").agg(sum("count")).collect.toSet)
-    } finally {
-      Utils.deleteRecursively(path)
-    }
-  }
-
-  testOpaqueOnly("save and load without schema") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val df = makeDF(data, securityLevel, "id", "word", "count")
-    val path = Utils.createTempDir()
-    path.delete()
-    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
-    try {
-      val df2 = spark.read
-        .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
-        .load(path.toString)
-      assert(df.collect.toSet === df2.collect.toSet)
-      assert(df.groupBy("word").agg(sum("count")).collect.toSet
-        === df2.groupBy("word").agg(sum("count")).collect.toSet)
-    } finally {
-      Utils.deleteRecursively(path)
-    }
-  }
-
-  testOpaqueOnly("load from SQL with explicit schema") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val df = makeDF(data, securityLevel, "id", "word", "count")
-    val path = Utils.createTempDir()
-    path.delete()
-    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
-
-    try {
-      spark.sql(s"""
-        |CREATE TEMPORARY VIEW df2
-        |(${df.schema.toDDL})
-        |USING edu.berkeley.cs.rise.opaque.EncryptedSource
-        |OPTIONS (
-        |  path "${path}"
-        |)""".stripMargin)
-      val df2 = spark.sql(s"""
-        |SELECT * FROM df2
-        |""".stripMargin)
-
-      assert(df.collect.toSet === df2.collect.toSet)
-    } finally {
-      spark.catalog.dropTempView("df2")
-      Utils.deleteRecursively(path)
-    }
-  }
-
-  testOpaqueOnly("load from SQL without schema") { securityLevel =>
-    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-    val df = makeDF(data, securityLevel, "id", "word", "count")
-    val path = Utils.createTempDir()
-    path.delete()
-    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
-
-    try {
-      spark.sql(s"""
-        |CREATE TEMPORARY VIEW df2
-        |USING edu.berkeley.cs.rise.opaque.EncryptedSource
-        |OPTIONS (
-        |  path "${path}"
-        |)""".stripMargin)
-      val df2 = spark.sql(s"""
-        |SELECT * FROM df2
-        |""".stripMargin)
-
-      assert(df.collect.toSet === df2.collect.toSet)
-    } finally {
-      spark.catalog.dropTempView("df2")
-      Utils.deleteRecursively(path)
-    }
-  }
-
-  testAgainstSpark("SQL API") { securityLevel =>
-    val df = makeDF(
-      (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
-      securityLevel,
-      "a", "b", "c", "d", "x")
-    df.createTempView("df")
-    try {
-      spark.sql("SELECT * FROM df WHERE x > 10").collect
-    } finally {
-      spark.catalog.dropTempView("df")
-    }
-  }
-
-  testOpaqueOnly("cast error") { securityLevel =>
-    val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 1, 12345), 0.toByte))
-    val schema = StructType(Seq(
-      StructField("CalendarIntervalType", CalendarIntervalType),
-      StructField("NullType", NullType)))
-    val df = securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema))
-    // Trigger an Opaque exception by attempting an unsupported cast: CalendarIntervalType to
-    // StringType
-    val e = intercept[SparkException] {
-      withLoggingOff {
-        df.select($"CalendarIntervalType".cast(StringType)).collect
-      }
-    }
-    assert(e.getCause.isInstanceOf[OpaqueException])
-  }
-
-  testAgainstSpark("exp") { securityLevel =>
-    val data: Seq[(Double, Double)] = Seq(
-      (2.0, 3.0))
-    val schema = StructType(Seq(
-      StructField("x", DoubleType),
-      StructField("y", DoubleType)))
-
-    val df = securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema))
-
-    df.select(exp($"y")).collect
-  }
-
-  testAgainstSpark("vector multiply") { securityLevel =>
-    val data: Seq[(Array[Double], Double)] = Seq(
-      (Array[Double](1.0, 1.0, 1.0), 3.0))
-    val schema = StructType(Seq(
-      StructField("v", DataTypes.createArrayType(DoubleType)),
-      StructField("c", DoubleType)))
-
-    val df = securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema))
-
-    df.select(vectormultiply($"v", $"c")).collect
-  }
-
-  testAgainstSpark("dot product") { securityLevel =>
-    val data: Seq[(Array[Double], Array[Double])] = Seq(
-      (Array[Double](1.0, 1.0, 1.0), Array[Double](1.0, 1.0, 1.0)))
-    val schema = StructType(Seq(
-      StructField("v1", DataTypes.createArrayType(DoubleType)),
-      StructField("v2", DataTypes.createArrayType(DoubleType))))
-
-    val df = securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema))
-
-    df.select(dot($"v1", $"v2")).collect
-  }
-
-  testAgainstSpark("upper") { securityLevel =>
-    val data = Seq(("lower", "upper"), ("lower2", "upper2"))
-    val schema = StructType(Seq(
-      StructField("v1", StringType),
-      StructField("v2", StringType)))
-
-    val df = securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema))
-
-    df.select(upper($"v1")).collect
-  }
-
-  testAgainstSpark("upper with null") { securityLevel =>
-    val data = Seq(("lower", null.asInstanceOf[String]))
-
-    val df = makeDF(data, securityLevel, "v1", "v2")
-
-    df.select(upper($"v2")).collect
-  }
-
-  testAgainstSpark("vector sum") { securityLevel =>
-    val data: Seq[(Array[Double], Double)] = Seq(
-      (Array[Double](1.0, 2.0, 3.0), 4.0),
-      (Array[Double](5.0, 7.0, 7.0), 8.0))
-    val schema = StructType(Seq(
-      StructField("v", DataTypes.createArrayType(DoubleType)),
-      StructField("c", DoubleType)))
-
-    val df = securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema))
-
-    val vectorsum = new VectorSum
-    df.groupBy().agg(vectorsum($"v")).collect
-  }
-
-  testAgainstSpark("create array") { securityLevel =>
-    val data: Seq[(Double, Double)] = Seq(
-      (1.0, 2.0),
-      (3.0, 4.0))
-    val schema = StructType(Seq(
-      StructField("x1", DoubleType),
-      StructField("x2", DoubleType)))
-
-    val df = securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema))
-
-    df.select(array($"x1", $"x2").as("x")).collect
-  }
-
-  testAgainstSpark("limit with fewer returned values") { securityLevel =>
-    val data = Random.shuffle(for (i <- 0 until 256) yield (i, abc(i)))
-    val schema = StructType(Seq(
-      StructField("id", IntegerType),
-      StructField("word", StringType)))
-    val df = securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema))
-    df.sort($"id").limit(5).collect
-  }
-
-  testAgainstSpark("limit with more returned values") { securityLevel =>
-    val data = Random.shuffle(for (i <- 0 until 256) yield (i, abc(i)))
-    val schema = StructType(Seq(
-      StructField("id", IntegerType),
-      StructField("word", StringType)))
-    val df = securityLevel.applyTo(
-      spark.createDataFrame(
-        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-        schema))
-    df.sort($"id").limit(200).collect
-  }
-
-  testAgainstSpark("least squares") { securityLevel =>
-    LeastSquares.query(spark, securityLevel, "tiny", numPartitions).collect
-  }
-
-  testAgainstSpark("logistic regression") { securityLevel =>
-    LogisticRegression.train(spark, securityLevel, 1000, numPartitions)
-  }
-
-  testAgainstSpark("k-means") { securityLevel =>
-    import scala.math.Ordering.Implicits.seqDerivedOrdering
-    KMeans.train(spark, securityLevel, numPartitions, 10, 2, 3, 0.01).map(_.toSeq).sorted
-  }
-
-  testAgainstSpark("pagerank") { securityLevel =>
-    PageRank.run(spark, securityLevel, "256", numPartitions).collect.toSet
-  }
-
-  testAgainstSpark("TPC-H 9") { securityLevel =>
-    TPCH.tpch9(spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
-  }
-
-  testAgainstSpark("big data 1") { securityLevel =>
-    BigDataBenchmark.q1(spark, securityLevel, "tiny", numPartitions).collect
-  }
-
-  testAgainstSpark("big data 2") { securityLevel =>
-    BigDataBenchmark.q2(spark, securityLevel, "tiny", numPartitions).collect
-      .map { case Row(a: String, b: Double) => (a, b.toFloat) }
-      .sortBy(_._1)
-  }
-
-  testAgainstSpark("big data 3") { securityLevel =>
-    BigDataBenchmark.q3(spark, securityLevel, "tiny", numPartitions).collect
-  }
+  // testAgainstSpark("aggregate count") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "category", "price")
+
+  //   words.groupBy("category").agg(count("category").as("itemsInCategory"))
+  //     .collect.sortBy { case Row(category: String, _) => category }
+  // }
+
+  // testAgainstSpark("aggregate first") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "category", "price")
+
+  //   words.groupBy("category").agg(first("category").as("firstInCategory"))
+  //     .collect.sortBy { case Row(category: String, _) => category }
+  // }
+
+  // testAgainstSpark("aggregate last") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "category", "price")
+
+  //   words.groupBy("category").agg(last("category").as("lastInCategory"))
+  //     .collect.sortBy { case Row(category: String, _) => category }
+  // }
+
+  // testAgainstSpark("aggregate max") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "category", "price")
+
+  //   words.groupBy("category").agg(max("price").as("maxPrice"))
+  //     .collect.sortBy { case Row(category: String, _) => category }
+  // }
+
+  // testAgainstSpark("aggregate min") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "category", "price")
+
+  //   words.groupBy("category").agg(min("price").as("minPrice"))
+  //     .collect.sortBy { case Row(category: String, _) => category }
+  // }
+
+  // testAgainstSpark("aggregate sum") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "word", "count")
+
+  //   words.groupBy("word").agg(sum("count").as("totalCount"))
+  //     .collect.sortBy { case Row(word: String, _) => word }
+  // }
+
+  // testAgainstSpark("aggregate on multiple columns") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (abc(i), 1, 1.0f)
+  //   val words = makeDF(data, securityLevel, "str", "x", "y")
+
+  //   words.groupBy("str").agg(sum("y").as("totalY"), avg("x").as("avgX"))
+  //     .collect.sortBy { case Row(str: String, _, _) => str }
+  // }
+
+  // testAgainstSpark("global aggregate") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val words = makeDF(data, securityLevel, "id", "word", "count")
+  //   words.agg(sum("count").as("totalCount")).collect
+  // }
+
+  // testAgainstSpark("contains") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield(i.toString, abc(i))
+  //   val df = makeDF(data, securityLevel, "word", "abc")
+  //   df.filter($"word".contains(lit("1"))).collect
+  // }
+
+  // testAgainstSpark("between") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield(i.toString, i)
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.filter($"count".between(50, 150)).collect
+  // }
+
+  // testAgainstSpark("year") { securityLevel =>
+  //   val data = Seq(Tuple2(1, new java.sql.Date(new java.util.Date().getTime())))
+  //   val df = makeDF(data, securityLevel, "id", "date")
+  //   df.select(year($"date")).collect
+  // }
+
+  // testAgainstSpark("case when - 1 branch with else (string)") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.select(when(df("word") === "foo", "hi").otherwise("bye")).collect
+  // }
+
+  // testAgainstSpark("case when - 1 branch with else (int)") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.select(when(df("word") === "foo", 10).otherwise(30)).collect
+  // }
+
+  // testAgainstSpark("case when - 1 branch without else (string)") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.select(when(df("word") === "foo", "hi")).collect
+  // }
+
+  // testAgainstSpark("case when - 1 branch without else (int)") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.select(when(df("word") === "foo", 10)).collect 
+  // }
+
+  // testAgainstSpark("case when - 2 branch with else (string)") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.select(when(df("word") === "foo", "hi").when(df("word") === "baz", "hello").otherwise("bye")).collect
+  // }
+
+  // testAgainstSpark("case when - 2 branch with else (int)") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.select(when(df("word") === "foo", 10).when(df("word") === "baz", 20).otherwise(30)).collect
+  // }
+
+  // testAgainstSpark("case when - 2 branch without else (string)") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.select(when(df("word") === "foo", "hi").when(df("word") === "baz", "hello")).collect 
+  // }
+
+  // testAgainstSpark("case when - 2 branch without else (int)") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.select(when(df("word") === "foo", 3).when(df("word") === "baz", 2)).collect
+  // }
+
+  // testAgainstSpark("LIKE - Contains") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.filter($"word".like("%a%")).collect
+  // } 
+
+  // testAgainstSpark("LIKE - StartsWith") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.filter($"word".like("ba%")).collect
+  // } 
+
+  // testAgainstSpark("LIKE - EndsWith") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.filter($"word".like("%ar")).collect
+  // }
+
+  // testAgainstSpark("LIKE - Empty Pattern") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.filter($"word".like("")).collect
+  // }
+
+  // testAgainstSpark("LIKE - Match All") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.filter($"word".like("%")).collect
+  // }
+
+  // testAgainstSpark("LIKE - Single Wildcard") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.filter($"word".like("ba_")).collect
+  // }
+
+  // testAgainstSpark("LIKE - SQL API") { securityLevel =>
+  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+  //   val df = makeDF(data, securityLevel, "word", "count")
+  //   df.createTempView("df")
+  //   try {
+  //     spark.sql(""" SELECT word FROM df WHERE word LIKE '_a_' """).collect
+  //   } finally {
+  //     spark.catalog.dropTempView("df")
+  //   }
+  // }
+
+  // testOpaqueOnly("save and load with explicit schema") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val df = makeDF(data, securityLevel, "id", "word", "count")
+  //   val path = Utils.createTempDir()
+  //   path.delete()
+  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+  //   try {
+  //     val df2 = spark.read
+  //       .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
+  //       .schema(df.schema)
+  //       .load(path.toString)
+  //     assert(df.collect.toSet === df2.collect.toSet)
+  //     assert(df.groupBy("word").agg(sum("count")).collect.toSet
+  //       === df2.groupBy("word").agg(sum("count")).collect.toSet)
+  //   } finally {
+  //     Utils.deleteRecursively(path)
+  //   }
+  // }
+
+  // testOpaqueOnly("save and load without schema") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val df = makeDF(data, securityLevel, "id", "word", "count")
+  //   val path = Utils.createTempDir()
+  //   path.delete()
+  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+  //   try {
+  //     val df2 = spark.read
+  //       .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
+  //       .load(path.toString)
+  //     assert(df.collect.toSet === df2.collect.toSet)
+  //     assert(df.groupBy("word").agg(sum("count")).collect.toSet
+  //       === df2.groupBy("word").agg(sum("count")).collect.toSet)
+  //   } finally {
+  //     Utils.deleteRecursively(path)
+  //   }
+  // }
+
+  // testOpaqueOnly("load from SQL with explicit schema") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val df = makeDF(data, securityLevel, "id", "word", "count")
+  //   val path = Utils.createTempDir()
+  //   path.delete()
+  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+
+  //   try {
+  //     spark.sql(s"""
+  //       |CREATE TEMPORARY VIEW df2
+  //       |(${df.schema.toDDL})
+  //       |USING edu.berkeley.cs.rise.opaque.EncryptedSource
+  //       |OPTIONS (
+  //       |  path "${path}"
+  //       |)""".stripMargin)
+  //     val df2 = spark.sql(s"""
+  //       |SELECT * FROM df2
+  //       |""".stripMargin)
+
+  //     assert(df.collect.toSet === df2.collect.toSet)
+  //   } finally {
+  //     spark.catalog.dropTempView("df2")
+  //     Utils.deleteRecursively(path)
+  //   }
+  // }
+
+  // testOpaqueOnly("load from SQL without schema") { securityLevel =>
+  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+  //   val df = makeDF(data, securityLevel, "id", "word", "count")
+  //   val path = Utils.createTempDir()
+  //   path.delete()
+  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+
+  //   try {
+  //     spark.sql(s"""
+  //       |CREATE TEMPORARY VIEW df2
+  //       |USING edu.berkeley.cs.rise.opaque.EncryptedSource
+  //       |OPTIONS (
+  //       |  path "${path}"
+  //       |)""".stripMargin)
+  //     val df2 = spark.sql(s"""
+  //       |SELECT * FROM df2
+  //       |""".stripMargin)
+
+  //     assert(df.collect.toSet === df2.collect.toSet)
+  //   } finally {
+  //     spark.catalog.dropTempView("df2")
+  //     Utils.deleteRecursively(path)
+  //   }
+  // }
+
+  // testAgainstSpark("SQL API") { securityLevel =>
+  //   val df = makeDF(
+  //     (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
+  //     securityLevel,
+  //     "a", "b", "c", "d", "x")
+  //   df.createTempView("df")
+  //   try {
+  //     spark.sql("SELECT * FROM df WHERE x > 10").collect
+  //   } finally {
+  //     spark.catalog.dropTempView("df")
+  //   }
+  // }
+
+  // testOpaqueOnly("cast error") { securityLevel =>
+  //   val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 1, 12345), 0.toByte))
+  //   val schema = StructType(Seq(
+  //     StructField("CalendarIntervalType", CalendarIntervalType),
+  //     StructField("NullType", NullType)))
+  //   val df = securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema))
+  //   // Trigger an Opaque exception by attempting an unsupported cast: CalendarIntervalType to
+  //   // StringType
+  //   val e = intercept[SparkException] {
+  //     withLoggingOff {
+  //       df.select($"CalendarIntervalType".cast(StringType)).collect
+  //     }
+  //   }
+  //   assert(e.getCause.isInstanceOf[OpaqueException])
+  // }
+
+  // testAgainstSpark("exp") { securityLevel =>
+  //   val data: Seq[(Double, Double)] = Seq(
+  //     (2.0, 3.0))
+  //   val schema = StructType(Seq(
+  //     StructField("x", DoubleType),
+  //     StructField("y", DoubleType)))
+
+  //   val df = securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema))
+
+  //   df.select(exp($"y")).collect
+  // }
+
+  // testAgainstSpark("vector multiply") { securityLevel =>
+  //   val data: Seq[(Array[Double], Double)] = Seq(
+  //     (Array[Double](1.0, 1.0, 1.0), 3.0))
+  //   val schema = StructType(Seq(
+  //     StructField("v", DataTypes.createArrayType(DoubleType)),
+  //     StructField("c", DoubleType)))
+
+  //   val df = securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema))
+
+  //   df.select(vectormultiply($"v", $"c")).collect
+  // }
+
+  // testAgainstSpark("dot product") { securityLevel =>
+  //   val data: Seq[(Array[Double], Array[Double])] = Seq(
+  //     (Array[Double](1.0, 1.0, 1.0), Array[Double](1.0, 1.0, 1.0)))
+  //   val schema = StructType(Seq(
+  //     StructField("v1", DataTypes.createArrayType(DoubleType)),
+  //     StructField("v2", DataTypes.createArrayType(DoubleType))))
+
+  //   val df = securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema))
+
+  //   df.select(dot($"v1", $"v2")).collect
+  // }
+
+  // testAgainstSpark("upper") { securityLevel =>
+  //   val data = Seq(("lower", "upper"), ("lower2", "upper2"))
+  //   val schema = StructType(Seq(
+  //     StructField("v1", StringType),
+  //     StructField("v2", StringType)))
+
+  //   val df = securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema))
+
+  //   df.select(upper($"v1")).collect
+  // }
+
+  // testAgainstSpark("upper with null") { securityLevel =>
+  //   val data = Seq(("lower", null.asInstanceOf[String]))
+
+  //   val df = makeDF(data, securityLevel, "v1", "v2")
+
+  //   df.select(upper($"v2")).collect
+  // }
+
+  // testAgainstSpark("vector sum") { securityLevel =>
+  //   val data: Seq[(Array[Double], Double)] = Seq(
+  //     (Array[Double](1.0, 2.0, 3.0), 4.0),
+  //     (Array[Double](5.0, 7.0, 7.0), 8.0))
+  //   val schema = StructType(Seq(
+  //     StructField("v", DataTypes.createArrayType(DoubleType)),
+  //     StructField("c", DoubleType)))
+
+  //   val df = securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema))
+
+  //   val vectorsum = new VectorSum
+  //   df.groupBy().agg(vectorsum($"v")).collect
+  // }
+
+  // testAgainstSpark("create array") { securityLevel =>
+  //   val data: Seq[(Double, Double)] = Seq(
+  //     (1.0, 2.0),
+  //     (3.0, 4.0))
+  //   val schema = StructType(Seq(
+  //     StructField("x1", DoubleType),
+  //     StructField("x2", DoubleType)))
+
+  //   val df = securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema))
+
+  //   df.select(array($"x1", $"x2").as("x")).collect
+  // }
+
+  // testAgainstSpark("limit with fewer returned values") { securityLevel =>
+  //   val data = Random.shuffle(for (i <- 0 until 256) yield (i, abc(i)))
+  //   val schema = StructType(Seq(
+  //     StructField("id", IntegerType),
+  //     StructField("word", StringType)))
+  //   val df = securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema))
+  //   df.sort($"id").limit(5).collect
+  // }
+
+  // testAgainstSpark("limit with more returned values") { securityLevel =>
+  //   val data = Random.shuffle(for (i <- 0 until 256) yield (i, abc(i)))
+  //   val schema = StructType(Seq(
+  //     StructField("id", IntegerType),
+  //     StructField("word", StringType)))
+  //   val df = securityLevel.applyTo(
+  //     spark.createDataFrame(
+  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+  //       schema))
+  //   df.sort($"id").limit(200).collect
+  // }
+
+  // testAgainstSpark("least squares") { securityLevel =>
+  //   LeastSquares.query(spark, securityLevel, "tiny", numPartitions).collect
+  // }
+
+  // testAgainstSpark("logistic regression") { securityLevel =>
+  //   LogisticRegression.train(spark, securityLevel, 1000, numPartitions)
+  // }
+
+  // testAgainstSpark("k-means") { securityLevel =>
+  //   import scala.math.Ordering.Implicits.seqDerivedOrdering
+  //   KMeans.train(spark, securityLevel, numPartitions, 10, 2, 3, 0.01).map(_.toSeq).sorted
+  // }
+
+  // testAgainstSpark("pagerank") { securityLevel =>
+  //   PageRank.run(spark, securityLevel, "256", numPartitions).collect.toSet
+  // }
+
+  // testAgainstSpark("TPC-H 9") { securityLevel =>
+  //   TPCH.tpch9(spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
+  // }
+
+  // testAgainstSpark("big data 1") { securityLevel =>
+  //   BigDataBenchmark.q1(spark, securityLevel, "tiny", numPartitions).collect
+  // }
+
+  // testAgainstSpark("big data 2") { securityLevel =>
+  //   BigDataBenchmark.q2(spark, securityLevel, "tiny", numPartitions).collect
+  //     .map { case Row(a: String, b: Double) => (a, b.toFloat) }
+  //     .sortBy(_._1)
+  // }
+
+  // testAgainstSpark("big data 3") { securityLevel =>
+  //   BigDataBenchmark.q3(spark, securityLevel, "tiny", numPartitions).collect
+  // }
 
   def makeDF[A <: Product : scala.reflect.ClassTag : scala.reflect.runtime.universe.TypeTag](
     data: Seq[A], securityLevel: SecurityLevel, columnNames: String*): DataFrame =

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -122,212 +122,212 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     }
   }
 
-  // testAgainstSpark("create DataFrame from sequence") { securityLevel =>
-  //   val data = for (i <- 0 until 5) yield ("foo", i)
-  //   makeDF(data, securityLevel, "word", "count").collect
-  // }
+  testAgainstSpark("create DataFrame from sequence") { securityLevel =>
+    val data = for (i <- 0 until 5) yield ("foo", i)
+    makeDF(data, securityLevel, "word", "count").collect
+  }
 
-  // testAgainstSpark("create DataFrame with BinaryType + ByteType") { securityLevel =>
-  //   val data: Seq[(Array[Byte], Byte)] =
-  //     Seq((Array[Byte](0.toByte, -128.toByte, 127.toByte), 42.toByte))
-  //   makeDF(data, securityLevel, "BinaryType", "ByteType").collect
-  // }
+  testAgainstSpark("create DataFrame with BinaryType + ByteType") { securityLevel =>
+    val data: Seq[(Array[Byte], Byte)] =
+      Seq((Array[Byte](0.toByte, -128.toByte, 127.toByte), 42.toByte))
+    makeDF(data, securityLevel, "BinaryType", "ByteType").collect
+  }
 
-  // testAgainstSpark("create DataFrame with CalendarIntervalType + NullType") { securityLevel =>
-  //   val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 1, 12345), 0.toByte))
-  //   val schema = StructType(Seq(
-  //     StructField("CalendarIntervalType", CalendarIntervalType),
-  //     StructField("NullType", NullType)))
+  testAgainstSpark("create DataFrame with CalendarIntervalType + NullType") { securityLevel =>
+    val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 1, 12345), 0.toByte))
+    val schema = StructType(Seq(
+      StructField("CalendarIntervalType", CalendarIntervalType),
+      StructField("NullType", NullType)))
 
-  //   securityLevel.applyTo(
-  //     spark.createDataFrame(
-  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-  //       schema)).collect
-  // }
+    securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema)).collect
+  }
 
-  // testAgainstSpark("create DataFrame with ShortType + TimestampType") { securityLevel =>
-  //   val data: Seq[(Short, Timestamp)] = Seq((13.toShort, Timestamp.valueOf("2017-12-02 03:04:00")))
-  //   makeDF(data, securityLevel, "ShortType", "TimestampType").collect
-  // }
+  testAgainstSpark("create DataFrame with ShortType + TimestampType") { securityLevel =>
+    val data: Seq[(Short, Timestamp)] = Seq((13.toShort, Timestamp.valueOf("2017-12-02 03:04:00")))
+    makeDF(data, securityLevel, "ShortType", "TimestampType").collect
+  }
 
-  // testAgainstSpark("create DataFrame with ArrayType") { securityLevel =>
-  //   val array: Array[Int] = Array(0, -128, 127, 1)
-  //   val data = Seq(
-  //     (array, "dog"),
-  //     (array, "cat"),
-  //     (array, "ant"))
-  //   val df = makeDF(data, securityLevel, "array", "string")
-  //   df.collect
-  // }
+  testAgainstSpark("create DataFrame with ArrayType") { securityLevel =>
+    val array: Array[Int] = Array(0, -128, 127, 1)
+    val data = Seq(
+      (array, "dog"),
+      (array, "cat"),
+      (array, "ant"))
+    val df = makeDF(data, securityLevel, "array", "string")
+    df.collect
+  }
 
-  // testAgainstSpark("create DataFrame with MapType") { securityLevel =>
-  //   val map: Map[String, Int] = Map("x" -> 24, "y" -> 25, "z" -> 26)
-  //   val data = Seq(
-  //     (map, "dog"),
-  //     (map, "cat"),
-  //     (map, "ant"))
-  //   val df = makeDF(data, securityLevel, "map", "string")
-  //   df.collect
-  // }
+  testAgainstSpark("create DataFrame with MapType") { securityLevel =>
+    val map: Map[String, Int] = Map("x" -> 24, "y" -> 25, "z" -> 26)
+    val data = Seq(
+      (map, "dog"),
+      (map, "cat"),
+      (map, "ant"))
+    val df = makeDF(data, securityLevel, "map", "string")
+    df.collect
+  }
 
-  // testAgainstSpark("create DataFrame with nulls for all types") { securityLevel =>
-  //   val schema = StructType(Seq(
-  //     StructField("boolean", BooleanType),
-  //     StructField("integer", IntegerType),
-  //     StructField("long", LongType),
-  //     StructField("float", FloatType),
-  //     StructField("double", DoubleType),
-  //     StructField("date", DateType),
-  //     StructField("binary", BinaryType),
-  //     StructField("byte", ByteType),
-  //     StructField("calendar_interval", CalendarIntervalType),
-  //     StructField("null", NullType),
-  //     StructField("short", ShortType),
-  //     StructField("timestamp", TimestampType),
-  //     StructField("array_of_int", DataTypes.createArrayType(IntegerType)),
-  //     StructField("map_int_to_int", DataTypes.createMapType(IntegerType, IntegerType)),
-  //     StructField("string", StringType)))
+  testAgainstSpark("create DataFrame with nulls for all types") { securityLevel =>
+    val schema = StructType(Seq(
+      StructField("boolean", BooleanType),
+      StructField("integer", IntegerType),
+      StructField("long", LongType),
+      StructField("float", FloatType),
+      StructField("double", DoubleType),
+      StructField("date", DateType),
+      StructField("binary", BinaryType),
+      StructField("byte", ByteType),
+      StructField("calendar_interval", CalendarIntervalType),
+      StructField("null", NullType),
+      StructField("short", ShortType),
+      StructField("timestamp", TimestampType),
+      StructField("array_of_int", DataTypes.createArrayType(IntegerType)),
+      StructField("map_int_to_int", DataTypes.createMapType(IntegerType, IntegerType)),
+      StructField("string", StringType)))
 
-  //   securityLevel.applyTo(
-  //     spark.createDataFrame(
-  //       spark.sparkContext.makeRDD(Seq(Row.fromSeq(Seq.fill(schema.length) { null })), numPartitions),
-  //       schema)).collect
-  // }
+    securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(Seq(Row.fromSeq(Seq.fill(schema.length) { null })), numPartitions),
+        schema)).collect
+  }
 
-  // testAgainstSpark("filter") { securityLevel =>
-  //   val df = makeDF(
-  //     (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
-  //     securityLevel,
-  //     "a", "b", "c", "d", "x")
-  //   df.filter($"x" > lit(10)).collect
-  // }
+  testAgainstSpark("filter") { securityLevel =>
+    val df = makeDF(
+      (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
+      securityLevel,
+      "a", "b", "c", "d", "x")
+    df.filter($"x" > lit(10)).collect
+  }
 
-  // testAgainstSpark("filter with NULLs") { securityLevel =>
-  //   val data: Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
-  //     if (x % 3 == 0)
-  //       Tuple1(null.asInstanceOf[Integer])
-  //     else
-  //       Tuple1(x.asInstanceOf[Integer])
-  //   }).toSeq)
-  //   val df = makeDF(data, securityLevel, "x")
-  //   df.filter($"x" > lit(10)).collect.toSet
-  // }
+  testAgainstSpark("filter with NULLs") { securityLevel =>
+    val data: Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
+      if (x % 3 == 0)
+        Tuple1(null.asInstanceOf[Integer])
+      else
+        Tuple1(x.asInstanceOf[Integer])
+    }).toSeq)
+    val df = makeDF(data, securityLevel, "x")
+    df.filter($"x" > lit(10)).collect.toSet
+  }
 
-  // testAgainstSpark("select") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield ("%03d".format(i) * 3, i.toFloat)
-  //   val df = makeDF(data, securityLevel, "str", "x")
-  //   df.select($"str").collect
-  // }
+  testAgainstSpark("select") { securityLevel =>
+    val data = for (i <- 0 until 256) yield ("%03d".format(i) * 3, i.toFloat)
+    val df = makeDF(data, securityLevel, "str", "x")
+    df.select($"str").collect
+  }
 
-  // testAgainstSpark("select with expressions") { securityLevel =>
-  //   val df = makeDF(
-  //     (1 to 20).map(x => (true, "hello world!", 1.0, 2.0f, x)),
-  //     securityLevel,
-  //     "a", "b", "c", "d", "x")
-  //   df.select(
-  //     $"x" + $"x" * $"x" - $"x",
-  //     substring($"b", 5, 20),
-  //     $"x" > $"x",
-  //     $"x" >= $"x",
-  //     $"x" <= $"x").collect.toSet
-  // }
+  testAgainstSpark("select with expressions") { securityLevel =>
+    val df = makeDF(
+      (1 to 20).map(x => (true, "hello world!", 1.0, 2.0f, x)),
+      securityLevel,
+      "a", "b", "c", "d", "x")
+    df.select(
+      $"x" + $"x" * $"x" - $"x",
+      substring($"b", 5, 20),
+      $"x" > $"x",
+      $"x" >= $"x",
+      $"x" <= $"x").collect.toSet
+  }
 
-  // testAgainstSpark("union") { securityLevel =>
-  //   val df1 = makeDF(
-  //     (1 to 20).map(x => (x, x.toString)).reverse,
-  //     securityLevel,
-  //     "a", "b")
-  //   val df2 = makeDF(
-  //     (1 to 20).map(x => (x, (x + 1).toString)),
-  //     securityLevel,
-  //     "a", "b")
-  //   df1.union(df2).collect.toSet
-  // }
+  testAgainstSpark("union") { securityLevel =>
+    val df1 = makeDF(
+      (1 to 20).map(x => (x, x.toString)).reverse,
+      securityLevel,
+      "a", "b")
+    val df2 = makeDF(
+      (1 to 20).map(x => (x, (x + 1).toString)),
+      securityLevel,
+      "a", "b")
+    df1.union(df2).collect.toSet
+  }
 
-  // testOpaqueOnly("cache") { securityLevel =>
-  //   def numCached(ds: Dataset[_]): Int =
-  //     ds.queryExecution.executedPlan.collect {
-  //       case cached: EncryptedBlockRDDScanExec
-  //           if cached.rdd.getStorageLevel != StorageLevel.NONE =>
-  //         cached
-  //     }.size
+  testOpaqueOnly("cache") { securityLevel =>
+    def numCached(ds: Dataset[_]): Int =
+      ds.queryExecution.executedPlan.collect {
+        case cached: EncryptedBlockRDDScanExec
+            if cached.rdd.getStorageLevel != StorageLevel.NONE =>
+          cached
+      }.size
 
-  //   val data = List((1, 3), (1, 4), (1, 5), (2, 4))
-  //   val df = makeDF(data, securityLevel, "a", "b").cache()
+    val data = List((1, 3), (1, 4), (1, 5), (2, 4))
+    val df = makeDF(data, securityLevel, "a", "b").cache()
 
-  //   val agg = df.groupBy($"a").agg(sum("b"))
+    val agg = df.groupBy($"a").agg(sum("b"))
 
-  //   assert(numCached(agg) === 1)
+    assert(numCached(agg) === 1)
 
-  //   val expected = data.groupBy(_._1).mapValues(_.map(_._2).sum)
-  //   assert(agg.collect.toSet === expected.map(Row.fromTuple).toSet)
-  //   df.unpersist()
-  // }
+    val expected = data.groupBy(_._1).mapValues(_.map(_._2).sum)
+    assert(agg.collect.toSet === expected.map(Row.fromTuple).toSet)
+    df.unpersist()
+  }
 
-  // testAgainstSpark("sort") { securityLevel =>
-  //   val data = Random.shuffle((0 until 256).map(x => (x.toString, x)).toSeq)
-  //   val df = makeDF(data, securityLevel, "str", "x")
-  //   df.sort($"x").collect
-  // }
+  testAgainstSpark("sort") { securityLevel =>
+    val data = Random.shuffle((0 until 256).map(x => (x.toString, x)).toSeq)
+    val df = makeDF(data, securityLevel, "str", "x")
+    df.sort($"x").collect
+  }
 
-  // testAgainstSpark("sort zero elements") { securityLevel =>
-  //   val data = Seq.empty[(String, Int)]
-  //   val df = makeDF(data, securityLevel, "str", "x")
-  //   df.sort($"x").collect
-  // }
+  testAgainstSpark("sort zero elements") { securityLevel =>
+    val data = Seq.empty[(String, Int)]
+    val df = makeDF(data, securityLevel, "str", "x")
+    df.sort($"x").collect
+  }
 
-  // testAgainstSpark("sort by float") { securityLevel =>
-  //   val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
-  //   val df = makeDF(data, securityLevel, "str", "x")
-  //   df.sort($"x").collect
-  // }
+  testAgainstSpark("sort by float") { securityLevel =>
+    val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
+    val df = makeDF(data, securityLevel, "str", "x")
+    df.sort($"x").collect
+  }
 
-  // testAgainstSpark("sort by string") { securityLevel =>
-  //   val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
-  //   val df = makeDF(data, securityLevel, "str", "x")
-  //   df.sort($"str").collect
-  // }
+  testAgainstSpark("sort by string") { securityLevel =>
+    val data = Random.shuffle((0 until 256).map(x => (x.toString, x.toFloat)).toSeq)
+    val df = makeDF(data, securityLevel, "str", "x")
+    df.sort($"str").collect
+  }
 
-  // testAgainstSpark("sort by 2 columns") { securityLevel =>
-  //   val data = Random.shuffle((0 until 256).map(x => (x / 16, x)).toSeq)
-  //   val df = makeDF(data, securityLevel, "x", "y")
-  //   df.sort($"x", $"y").collect
-  // }
+  testAgainstSpark("sort by 2 columns") { securityLevel =>
+    val data = Random.shuffle((0 until 256).map(x => (x / 16, x)).toSeq)
+    val df = makeDF(data, securityLevel, "x", "y")
+    df.sort($"x", $"y").collect
+  }
 
-  // testAgainstSpark("sort with null values") { securityLevel =>
-  //   val data: Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
-  //     if (x % 3 == 0)
-  //       Tuple1(null.asInstanceOf[Integer])
-  //     else
-  //       Tuple1(x.asInstanceOf[Integer])
-  //   }).toSeq)
-  //   val df = makeDF(data, securityLevel, "x")
-  //   df.sort($"x").collect
-  // }
+  testAgainstSpark("sort with null values") { securityLevel =>
+    val data: Seq[Tuple1[Integer]] = Random.shuffle((0 until 256).map(x => {
+      if (x % 3 == 0)
+        Tuple1(null.asInstanceOf[Integer])
+      else
+        Tuple1(x.asInstanceOf[Integer])
+    }).toSeq)
+    val df = makeDF(data, securityLevel, "x")
+    df.sort($"x").collect
+  }
 
-  // testAgainstSpark("join") { securityLevel =>
-  //   val p_data = for (i <- 1 to 16) yield (i, i.toString, i * 10)
-  //   val f_data = for (i <- 1 to 256 - 16) yield (i, (i % 16).toString, i * 10)
-  //   val p = makeDF(p_data, securityLevel, "id", "pk", "x")
-  //   val f = makeDF(f_data, securityLevel, "id", "fk", "x")
-  //   p.join(f, $"pk" === $"fk").collect.toSet
-  // }
+  testAgainstSpark("join") { securityLevel =>
+    val p_data = for (i <- 1 to 16) yield (i, i.toString, i * 10)
+    val f_data = for (i <- 1 to 256 - 16) yield (i, (i % 16).toString, i * 10)
+    val p = makeDF(p_data, securityLevel, "id", "pk", "x")
+    val f = makeDF(f_data, securityLevel, "id", "fk", "x")
+    p.join(f, $"pk" === $"fk").collect.toSet
+  }
 
-  // testAgainstSpark("join on column 1") { securityLevel =>
-  //   val p_data = for (i <- 1 to 16) yield (i.toString, i * 10)
-  //   val f_data = for (i <- 1 to 256 - 16) yield ((i % 16).toString, (i * 10).toString, i.toFloat)
-  //   val p = makeDF(p_data, securityLevel, "pk", "x")
-  //   val f = makeDF(f_data, securityLevel, "fk", "x", "y")
-  //   p.join(f, $"pk" === $"fk").collect.toSet
-  // }
+  testAgainstSpark("join on column 1") { securityLevel =>
+    val p_data = for (i <- 1 to 16) yield (i.toString, i * 10)
+    val f_data = for (i <- 1 to 256 - 16) yield ((i % 16).toString, (i * 10).toString, i.toFloat)
+    val p = makeDF(p_data, securityLevel, "pk", "x")
+    val f = makeDF(f_data, securityLevel, "fk", "x", "y")
+    p.join(f, $"pk" === $"fk").collect.toSet
+  }
 
-  // testAgainstSpark("non-foreign-key join") { securityLevel =>
-  //   val p_data = for (i <- 1 to 128) yield (i, (i % 16).toString, i * 10)
-  //   val f_data = for (i <- 1 to 256 - 128) yield (i, (i % 16).toString, i * 10)
-  //   val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
-  //   val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
-  //   p.join(f, $"join_col_1" === $"join_col_2").collect.toSet
-  // }
+  testAgainstSpark("non-foreign-key join") { securityLevel =>
+    val p_data = for (i <- 1 to 128) yield (i, (i % 16).toString, i * 10)
+    val f_data = for (i <- 1 to 256 - 128) yield (i, (i % 16).toString, i * 10)
+    val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
+    val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
+    p.join(f, $"join_col_1" === $"join_col_2").collect.toSet
+  }
 
   def abc(i: Int): String = (i % 3) match {
     case 0 => "A"
@@ -340,464 +340,462 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     val words = makeDF(data, securityLevel, "id", "category", "price")
 
     val result = words.groupBy("category").agg(avg("price"))
-    result.explain()
-    result
+    result.collect.sortBy { case Row(category: String, _) => category }
+  }
+
+  testAgainstSpark("aggregate count") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+    val words = makeDF(data, securityLevel, "id", "category", "price")
+
+    words.groupBy("category").agg(count("category").as("itemsInCategory"))
       .collect.sortBy { case Row(category: String, _) => category }
   }
 
-  // testAgainstSpark("aggregate count") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-  //   val words = makeDF(data, securityLevel, "id", "category", "price")
-
-  //   words.groupBy("category").agg(count("category").as("itemsInCategory"))
-  //     .collect.sortBy { case Row(category: String, _) => category }
-  // }
-
-  // testAgainstSpark("aggregate first") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-  //   val words = makeDF(data, securityLevel, "id", "category", "price")
-
-  //   words.groupBy("category").agg(first("category").as("firstInCategory"))
-  //     .collect.sortBy { case Row(category: String, _) => category }
-  // }
-
-  // testAgainstSpark("aggregate last") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-  //   val words = makeDF(data, securityLevel, "id", "category", "price")
-
-  //   words.groupBy("category").agg(last("category").as("lastInCategory"))
-  //     .collect.sortBy { case Row(category: String, _) => category }
-  // }
-
-  // testAgainstSpark("aggregate max") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-  //   val words = makeDF(data, securityLevel, "id", "category", "price")
-
-  //   words.groupBy("category").agg(max("price").as("maxPrice"))
-  //     .collect.sortBy { case Row(category: String, _) => category }
-  // }
-
-  // testAgainstSpark("aggregate min") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-  //   val words = makeDF(data, securityLevel, "id", "category", "price")
-
-  //   words.groupBy("category").agg(min("price").as("minPrice"))
-  //     .collect.sortBy { case Row(category: String, _) => category }
-  // }
-
-  // testAgainstSpark("aggregate sum") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-  //   val words = makeDF(data, securityLevel, "id", "word", "count")
-
-  //   words.groupBy("word").agg(sum("count").as("totalCount"))
-  //     .collect.sortBy { case Row(word: String, _) => word }
-  // }
-
-  // testAgainstSpark("aggregate on multiple columns") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (abc(i), 1, 1.0f)
-  //   val words = makeDF(data, securityLevel, "str", "x", "y")
-
-  //   words.groupBy("str").agg(sum("y").as("totalY"), avg("x").as("avgX"))
-  //     .collect.sortBy { case Row(str: String, _, _) => str }
-  // }
-
-  // testAgainstSpark("global aggregate") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-  //   val words = makeDF(data, securityLevel, "id", "word", "count")
-  //   words.agg(sum("count").as("totalCount")).collect
-  // }
-
-  // testAgainstSpark("contains") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield(i.toString, abc(i))
-  //   val df = makeDF(data, securityLevel, "word", "abc")
-  //   df.filter($"word".contains(lit("1"))).collect
-  // }
-
-  // testAgainstSpark("between") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield(i.toString, i)
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.filter($"count".between(50, 150)).collect
-  // }
-
-  // testAgainstSpark("year") { securityLevel =>
-  //   val data = Seq(Tuple2(1, new java.sql.Date(new java.util.Date().getTime())))
-  //   val df = makeDF(data, securityLevel, "id", "date")
-  //   df.select(year($"date")).collect
-  // }
-
-  // testAgainstSpark("case when - 1 branch with else (string)") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.select(when(df("word") === "foo", "hi").otherwise("bye")).collect
-  // }
-
-  // testAgainstSpark("case when - 1 branch with else (int)") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.select(when(df("word") === "foo", 10).otherwise(30)).collect
-  // }
-
-  // testAgainstSpark("case when - 1 branch without else (string)") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.select(when(df("word") === "foo", "hi")).collect
-  // }
-
-  // testAgainstSpark("case when - 1 branch without else (int)") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.select(when(df("word") === "foo", 10)).collect 
-  // }
-
-  // testAgainstSpark("case when - 2 branch with else (string)") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.select(when(df("word") === "foo", "hi").when(df("word") === "baz", "hello").otherwise("bye")).collect
-  // }
-
-  // testAgainstSpark("case when - 2 branch with else (int)") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.select(when(df("word") === "foo", 10).when(df("word") === "baz", 20).otherwise(30)).collect
-  // }
-
-  // testAgainstSpark("case when - 2 branch without else (string)") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.select(when(df("word") === "foo", "hi").when(df("word") === "baz", "hello")).collect 
-  // }
-
-  // testAgainstSpark("case when - 2 branch without else (int)") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.select(when(df("word") === "foo", 3).when(df("word") === "baz", 2)).collect
-  // }
-
-  // testAgainstSpark("LIKE - Contains") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.filter($"word".like("%a%")).collect
-  // } 
-
-  // testAgainstSpark("LIKE - StartsWith") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.filter($"word".like("ba%")).collect
-  // } 
-
-  // testAgainstSpark("LIKE - EndsWith") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.filter($"word".like("%ar")).collect
-  // }
-
-  // testAgainstSpark("LIKE - Empty Pattern") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.filter($"word".like("")).collect
-  // }
-
-  // testAgainstSpark("LIKE - Match All") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.filter($"word".like("%")).collect
-  // }
-
-  // testAgainstSpark("LIKE - Single Wildcard") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.filter($"word".like("ba_")).collect
-  // }
-
-  // testAgainstSpark("LIKE - SQL API") { securityLevel =>
-  //   val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
-  //   val df = makeDF(data, securityLevel, "word", "count")
-  //   df.createTempView("df")
-  //   try {
-  //     spark.sql(""" SELECT word FROM df WHERE word LIKE '_a_' """).collect
-  //   } finally {
-  //     spark.catalog.dropTempView("df")
-  //   }
-  // }
-
-  // testOpaqueOnly("save and load with explicit schema") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-  //   val df = makeDF(data, securityLevel, "id", "word", "count")
-  //   val path = Utils.createTempDir()
-  //   path.delete()
-  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
-  //   try {
-  //     val df2 = spark.read
-  //       .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
-  //       .schema(df.schema)
-  //       .load(path.toString)
-  //     assert(df.collect.toSet === df2.collect.toSet)
-  //     assert(df.groupBy("word").agg(sum("count")).collect.toSet
-  //       === df2.groupBy("word").agg(sum("count")).collect.toSet)
-  //   } finally {
-  //     Utils.deleteRecursively(path)
-  //   }
-  // }
-
-  // testOpaqueOnly("save and load without schema") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-  //   val df = makeDF(data, securityLevel, "id", "word", "count")
-  //   val path = Utils.createTempDir()
-  //   path.delete()
-  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
-  //   try {
-  //     val df2 = spark.read
-  //       .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
-  //       .load(path.toString)
-  //     assert(df.collect.toSet === df2.collect.toSet)
-  //     assert(df.groupBy("word").agg(sum("count")).collect.toSet
-  //       === df2.groupBy("word").agg(sum("count")).collect.toSet)
-  //   } finally {
-  //     Utils.deleteRecursively(path)
-  //   }
-  // }
-
-  // testOpaqueOnly("load from SQL with explicit schema") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-  //   val df = makeDF(data, securityLevel, "id", "word", "count")
-  //   val path = Utils.createTempDir()
-  //   path.delete()
-  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
-
-  //   try {
-  //     spark.sql(s"""
-  //       |CREATE TEMPORARY VIEW df2
-  //       |(${df.schema.toDDL})
-  //       |USING edu.berkeley.cs.rise.opaque.EncryptedSource
-  //       |OPTIONS (
-  //       |  path "${path}"
-  //       |)""".stripMargin)
-  //     val df2 = spark.sql(s"""
-  //       |SELECT * FROM df2
-  //       |""".stripMargin)
-
-  //     assert(df.collect.toSet === df2.collect.toSet)
-  //   } finally {
-  //     spark.catalog.dropTempView("df2")
-  //     Utils.deleteRecursively(path)
-  //   }
-  // }
-
-  // testOpaqueOnly("load from SQL without schema") { securityLevel =>
-  //   val data = for (i <- 0 until 256) yield (i, abc(i), 1)
-  //   val df = makeDF(data, securityLevel, "id", "word", "count")
-  //   val path = Utils.createTempDir()
-  //   path.delete()
-  //   df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
-
-  //   try {
-  //     spark.sql(s"""
-  //       |CREATE TEMPORARY VIEW df2
-  //       |USING edu.berkeley.cs.rise.opaque.EncryptedSource
-  //       |OPTIONS (
-  //       |  path "${path}"
-  //       |)""".stripMargin)
-  //     val df2 = spark.sql(s"""
-  //       |SELECT * FROM df2
-  //       |""".stripMargin)
-
-  //     assert(df.collect.toSet === df2.collect.toSet)
-  //   } finally {
-  //     spark.catalog.dropTempView("df2")
-  //     Utils.deleteRecursively(path)
-  //   }
-  // }
-
-  // testAgainstSpark("SQL API") { securityLevel =>
-  //   val df = makeDF(
-  //     (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
-  //     securityLevel,
-  //     "a", "b", "c", "d", "x")
-  //   df.createTempView("df")
-  //   try {
-  //     spark.sql("SELECT * FROM df WHERE x > 10").collect
-  //   } finally {
-  //     spark.catalog.dropTempView("df")
-  //   }
-  // }
-
-  // testOpaqueOnly("cast error") { securityLevel =>
-  //   val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 1, 12345), 0.toByte))
-  //   val schema = StructType(Seq(
-  //     StructField("CalendarIntervalType", CalendarIntervalType),
-  //     StructField("NullType", NullType)))
-  //   val df = securityLevel.applyTo(
-  //     spark.createDataFrame(
-  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-  //       schema))
-  //   // Trigger an Opaque exception by attempting an unsupported cast: CalendarIntervalType to
-  //   // StringType
-  //   val e = intercept[SparkException] {
-  //     withLoggingOff {
-  //       df.select($"CalendarIntervalType".cast(StringType)).collect
-  //     }
-  //   }
-  //   assert(e.getCause.isInstanceOf[OpaqueException])
-  // }
-
-  // testAgainstSpark("exp") { securityLevel =>
-  //   val data: Seq[(Double, Double)] = Seq(
-  //     (2.0, 3.0))
-  //   val schema = StructType(Seq(
-  //     StructField("x", DoubleType),
-  //     StructField("y", DoubleType)))
-
-  //   val df = securityLevel.applyTo(
-  //     spark.createDataFrame(
-  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-  //       schema))
-
-  //   df.select(exp($"y")).collect
-  // }
-
-  // testAgainstSpark("vector multiply") { securityLevel =>
-  //   val data: Seq[(Array[Double], Double)] = Seq(
-  //     (Array[Double](1.0, 1.0, 1.0), 3.0))
-  //   val schema = StructType(Seq(
-  //     StructField("v", DataTypes.createArrayType(DoubleType)),
-  //     StructField("c", DoubleType)))
-
-  //   val df = securityLevel.applyTo(
-  //     spark.createDataFrame(
-  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-  //       schema))
-
-  //   df.select(vectormultiply($"v", $"c")).collect
-  // }
-
-  // testAgainstSpark("dot product") { securityLevel =>
-  //   val data: Seq[(Array[Double], Array[Double])] = Seq(
-  //     (Array[Double](1.0, 1.0, 1.0), Array[Double](1.0, 1.0, 1.0)))
-  //   val schema = StructType(Seq(
-  //     StructField("v1", DataTypes.createArrayType(DoubleType)),
-  //     StructField("v2", DataTypes.createArrayType(DoubleType))))
-
-  //   val df = securityLevel.applyTo(
-  //     spark.createDataFrame(
-  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-  //       schema))
-
-  //   df.select(dot($"v1", $"v2")).collect
-  // }
-
-  // testAgainstSpark("upper") { securityLevel =>
-  //   val data = Seq(("lower", "upper"), ("lower2", "upper2"))
-  //   val schema = StructType(Seq(
-  //     StructField("v1", StringType),
-  //     StructField("v2", StringType)))
-
-  //   val df = securityLevel.applyTo(
-  //     spark.createDataFrame(
-  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-  //       schema))
-
-  //   df.select(upper($"v1")).collect
-  // }
-
-  // testAgainstSpark("upper with null") { securityLevel =>
-  //   val data = Seq(("lower", null.asInstanceOf[String]))
-
-  //   val df = makeDF(data, securityLevel, "v1", "v2")
-
-  //   df.select(upper($"v2")).collect
-  // }
-
-  // testAgainstSpark("vector sum") { securityLevel =>
-  //   val data: Seq[(Array[Double], Double)] = Seq(
-  //     (Array[Double](1.0, 2.0, 3.0), 4.0),
-  //     (Array[Double](5.0, 7.0, 7.0), 8.0))
-  //   val schema = StructType(Seq(
-  //     StructField("v", DataTypes.createArrayType(DoubleType)),
-  //     StructField("c", DoubleType)))
-
-  //   val df = securityLevel.applyTo(
-  //     spark.createDataFrame(
-  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-  //       schema))
-
-  //   val vectorsum = new VectorSum
-  //   df.groupBy().agg(vectorsum($"v")).collect
-  // }
-
-  // testAgainstSpark("create array") { securityLevel =>
-  //   val data: Seq[(Double, Double)] = Seq(
-  //     (1.0, 2.0),
-  //     (3.0, 4.0))
-  //   val schema = StructType(Seq(
-  //     StructField("x1", DoubleType),
-  //     StructField("x2", DoubleType)))
-
-  //   val df = securityLevel.applyTo(
-  //     spark.createDataFrame(
-  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-  //       schema))
-
-  //   df.select(array($"x1", $"x2").as("x")).collect
-  // }
-
-  // testAgainstSpark("limit with fewer returned values") { securityLevel =>
-  //   val data = Random.shuffle(for (i <- 0 until 256) yield (i, abc(i)))
-  //   val schema = StructType(Seq(
-  //     StructField("id", IntegerType),
-  //     StructField("word", StringType)))
-  //   val df = securityLevel.applyTo(
-  //     spark.createDataFrame(
-  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-  //       schema))
-  //   df.sort($"id").limit(5).collect
-  // }
-
-  // testAgainstSpark("limit with more returned values") { securityLevel =>
-  //   val data = Random.shuffle(for (i <- 0 until 256) yield (i, abc(i)))
-  //   val schema = StructType(Seq(
-  //     StructField("id", IntegerType),
-  //     StructField("word", StringType)))
-  //   val df = securityLevel.applyTo(
-  //     spark.createDataFrame(
-  //       spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
-  //       schema))
-  //   df.sort($"id").limit(200).collect
-  // }
-
-  // testAgainstSpark("least squares") { securityLevel =>
-  //   LeastSquares.query(spark, securityLevel, "tiny", numPartitions).collect
-  // }
-
-  // testAgainstSpark("logistic regression") { securityLevel =>
-  //   LogisticRegression.train(spark, securityLevel, 1000, numPartitions)
-  // }
-
-  // testAgainstSpark("k-means") { securityLevel =>
-  //   import scala.math.Ordering.Implicits.seqDerivedOrdering
-  //   KMeans.train(spark, securityLevel, numPartitions, 10, 2, 3, 0.01).map(_.toSeq).sorted
-  // }
-
-  // testAgainstSpark("pagerank") { securityLevel =>
-  //   PageRank.run(spark, securityLevel, "256", numPartitions).collect.toSet
-  // }
-
-  // testAgainstSpark("TPC-H 9") { securityLevel =>
-  //   TPCH.tpch9(spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
-  // }
-
-  // testAgainstSpark("big data 1") { securityLevel =>
-  //   BigDataBenchmark.q1(spark, securityLevel, "tiny", numPartitions).collect
-  // }
-
-  // testAgainstSpark("big data 2") { securityLevel =>
-  //   BigDataBenchmark.q2(spark, securityLevel, "tiny", numPartitions).collect
-  //     .map { case Row(a: String, b: Double) => (a, b.toFloat) }
-  //     .sortBy(_._1)
-  // }
-
-  // testAgainstSpark("big data 3") { securityLevel =>
-  //   BigDataBenchmark.q3(spark, securityLevel, "tiny", numPartitions).collect
-  // }
+  testAgainstSpark("aggregate first") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+    val words = makeDF(data, securityLevel, "id", "category", "price")
+
+    words.groupBy("category").agg(first("category").as("firstInCategory"))
+      .collect.sortBy { case Row(category: String, _) => category }
+  }
+
+  testAgainstSpark("aggregate last") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+    val words = makeDF(data, securityLevel, "id", "category", "price")
+
+    words.groupBy("category").agg(last("category").as("lastInCategory"))
+      .collect.sortBy { case Row(category: String, _) => category }
+  }
+
+  testAgainstSpark("aggregate max") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+    val words = makeDF(data, securityLevel, "id", "category", "price")
+
+    words.groupBy("category").agg(max("price").as("maxPrice"))
+      .collect.sortBy { case Row(category: String, _) => category }
+  }
+
+  testAgainstSpark("aggregate min") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+    val words = makeDF(data, securityLevel, "id", "category", "price")
+
+    words.groupBy("category").agg(min("price").as("minPrice"))
+      .collect.sortBy { case Row(category: String, _) => category }
+  }
+
+  testAgainstSpark("aggregate sum") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+    val words = makeDF(data, securityLevel, "id", "word", "count")
+
+    words.groupBy("word").agg(sum("count").as("totalCount"))
+      .collect.sortBy { case Row(word: String, _) => word }
+  }
+
+  testAgainstSpark("aggregate on multiple columns") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (abc(i), 1, 1.0f)
+    val words = makeDF(data, securityLevel, "str", "x", "y")
+
+    words.groupBy("str").agg(sum("y").as("totalY"), avg("x").as("avgX"))
+      .collect.sortBy { case Row(str: String, _, _) => str }
+  }
+
+  testAgainstSpark("global aggregate") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+    val words = makeDF(data, securityLevel, "id", "word", "count")
+    words.agg(sum("count").as("totalCount")).collect
+  }
+
+  testAgainstSpark("contains") { securityLevel =>
+    val data = for (i <- 0 until 256) yield(i.toString, abc(i))
+    val df = makeDF(data, securityLevel, "word", "abc")
+    df.filter($"word".contains(lit("1"))).collect
+  }
+
+  testAgainstSpark("between") { securityLevel =>
+    val data = for (i <- 0 until 256) yield(i.toString, i)
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.filter($"count".between(50, 150)).collect
+  }
+
+  testAgainstSpark("year") { securityLevel =>
+    val data = Seq(Tuple2(1, new java.sql.Date(new java.util.Date().getTime())))
+    val df = makeDF(data, securityLevel, "id", "date")
+    df.select(year($"date")).collect
+  }
+
+  testAgainstSpark("case when - 1 branch with else (string)") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.select(when(df("word") === "foo", "hi").otherwise("bye")).collect
+  }
+
+  testAgainstSpark("case when - 1 branch with else (int)") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.select(when(df("word") === "foo", 10).otherwise(30)).collect
+  }
+
+  testAgainstSpark("case when - 1 branch without else (string)") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.select(when(df("word") === "foo", "hi")).collect
+  }
+
+  testAgainstSpark("case when - 1 branch without else (int)") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.select(when(df("word") === "foo", 10)).collect 
+  }
+
+  testAgainstSpark("case when - 2 branch with else (string)") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.select(when(df("word") === "foo", "hi").when(df("word") === "baz", "hello").otherwise("bye")).collect
+  }
+
+  testAgainstSpark("case when - 2 branch with else (int)") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.select(when(df("word") === "foo", 10).when(df("word") === "baz", 20).otherwise(30)).collect
+  }
+
+  testAgainstSpark("case when - 2 branch without else (string)") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.select(when(df("word") === "foo", "hi").when(df("word") === "baz", "hello")).collect 
+  }
+
+  testAgainstSpark("case when - 2 branch without else (int)") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), ("bear", null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.select(when(df("word") === "foo", 3).when(df("word") === "baz", 2)).collect
+  }
+
+  testAgainstSpark("LIKE - Contains") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.filter($"word".like("%a%")).collect
+  } 
+
+  testAgainstSpark("LIKE - StartsWith") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.filter($"word".like("ba%")).collect
+  } 
+
+  testAgainstSpark("LIKE - EndsWith") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.filter($"word".like("%ar")).collect
+  }
+
+  testAgainstSpark("LIKE - Empty Pattern") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.filter($"word".like("")).collect
+  }
+
+  testAgainstSpark("LIKE - Match All") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.filter($"word".like("%")).collect
+  }
+
+  testAgainstSpark("LIKE - Single Wildcard") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.filter($"word".like("ba_")).collect
+  }
+
+  testAgainstSpark("LIKE - SQL API") { securityLevel =>
+    val data = Seq(("foo", 4), ("bar", 1), ("baz", 5), (null.asInstanceOf[String], null.asInstanceOf[Int]))
+    val df = makeDF(data, securityLevel, "word", "count")
+    df.createTempView("df")
+    try {
+      spark.sql(""" SELECT word FROM df WHERE word LIKE '_a_' """).collect
+    } finally {
+      spark.catalog.dropTempView("df")
+    }
+  }
+
+  testOpaqueOnly("save and load with explicit schema") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+    val df = makeDF(data, securityLevel, "id", "word", "count")
+    val path = Utils.createTempDir()
+    path.delete()
+    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+    try {
+      val df2 = spark.read
+        .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
+        .schema(df.schema)
+        .load(path.toString)
+      assert(df.collect.toSet === df2.collect.toSet)
+      assert(df.groupBy("word").agg(sum("count")).collect.toSet
+        === df2.groupBy("word").agg(sum("count")).collect.toSet)
+    } finally {
+      Utils.deleteRecursively(path)
+    }
+  }
+
+  testOpaqueOnly("save and load without schema") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+    val df = makeDF(data, securityLevel, "id", "word", "count")
+    val path = Utils.createTempDir()
+    path.delete()
+    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+    try {
+      val df2 = spark.read
+        .format("edu.berkeley.cs.rise.opaque.EncryptedSource")
+        .load(path.toString)
+      assert(df.collect.toSet === df2.collect.toSet)
+      assert(df.groupBy("word").agg(sum("count")).collect.toSet
+        === df2.groupBy("word").agg(sum("count")).collect.toSet)
+    } finally {
+      Utils.deleteRecursively(path)
+    }
+  }
+
+  testOpaqueOnly("load from SQL with explicit schema") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+    val df = makeDF(data, securityLevel, "id", "word", "count")
+    val path = Utils.createTempDir()
+    path.delete()
+    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+
+    try {
+      spark.sql(s"""
+        |CREATE TEMPORARY VIEW df2
+        |(${df.schema.toDDL})
+        |USING edu.berkeley.cs.rise.opaque.EncryptedSource
+        |OPTIONS (
+        |  path "${path}"
+        |)""".stripMargin)
+      val df2 = spark.sql(s"""
+        |SELECT * FROM df2
+        |""".stripMargin)
+
+      assert(df.collect.toSet === df2.collect.toSet)
+    } finally {
+      spark.catalog.dropTempView("df2")
+      Utils.deleteRecursively(path)
+    }
+  }
+
+  testOpaqueOnly("load from SQL without schema") { securityLevel =>
+    val data = for (i <- 0 until 256) yield (i, abc(i), 1)
+    val df = makeDF(data, securityLevel, "id", "word", "count")
+    val path = Utils.createTempDir()
+    path.delete()
+    df.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save(path.toString)
+
+    try {
+      spark.sql(s"""
+        |CREATE TEMPORARY VIEW df2
+        |USING edu.berkeley.cs.rise.opaque.EncryptedSource
+        |OPTIONS (
+        |  path "${path}"
+        |)""".stripMargin)
+      val df2 = spark.sql(s"""
+        |SELECT * FROM df2
+        |""".stripMargin)
+
+      assert(df.collect.toSet === df2.collect.toSet)
+    } finally {
+      spark.catalog.dropTempView("df2")
+      Utils.deleteRecursively(path)
+    }
+  }
+
+  testAgainstSpark("SQL API") { securityLevel =>
+    val df = makeDF(
+      (1 to 20).map(x => (true, "hello", 1.0, 2.0f, x)),
+      securityLevel,
+      "a", "b", "c", "d", "x")
+    df.createTempView("df")
+    try {
+      spark.sql("SELECT * FROM df WHERE x > 10").collect
+    } finally {
+      spark.catalog.dropTempView("df")
+    }
+  }
+
+  testOpaqueOnly("cast error") { securityLevel =>
+    val data: Seq[(CalendarInterval, Byte)] = Seq((new CalendarInterval(12, 1, 12345), 0.toByte))
+    val schema = StructType(Seq(
+      StructField("CalendarIntervalType", CalendarIntervalType),
+      StructField("NullType", NullType)))
+    val df = securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema))
+    // Trigger an Opaque exception by attempting an unsupported cast: CalendarIntervalType to
+    // StringType
+    val e = intercept[SparkException] {
+      withLoggingOff {
+        df.select($"CalendarIntervalType".cast(StringType)).collect
+      }
+    }
+    assert(e.getCause.isInstanceOf[OpaqueException])
+  }
+
+  testAgainstSpark("exp") { securityLevel =>
+    val data: Seq[(Double, Double)] = Seq(
+      (2.0, 3.0))
+    val schema = StructType(Seq(
+      StructField("x", DoubleType),
+      StructField("y", DoubleType)))
+
+    val df = securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema))
+
+    df.select(exp($"y")).collect
+  }
+
+  testAgainstSpark("vector multiply") { securityLevel =>
+    val data: Seq[(Array[Double], Double)] = Seq(
+      (Array[Double](1.0, 1.0, 1.0), 3.0))
+    val schema = StructType(Seq(
+      StructField("v", DataTypes.createArrayType(DoubleType)),
+      StructField("c", DoubleType)))
+
+    val df = securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema))
+
+    df.select(vectormultiply($"v", $"c")).collect
+  }
+
+  testAgainstSpark("dot product") { securityLevel =>
+    val data: Seq[(Array[Double], Array[Double])] = Seq(
+      (Array[Double](1.0, 1.0, 1.0), Array[Double](1.0, 1.0, 1.0)))
+    val schema = StructType(Seq(
+      StructField("v1", DataTypes.createArrayType(DoubleType)),
+      StructField("v2", DataTypes.createArrayType(DoubleType))))
+
+    val df = securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema))
+
+    df.select(dot($"v1", $"v2")).collect
+  }
+
+  testAgainstSpark("upper") { securityLevel =>
+    val data = Seq(("lower", "upper"), ("lower2", "upper2"))
+    val schema = StructType(Seq(
+      StructField("v1", StringType),
+      StructField("v2", StringType)))
+
+    val df = securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema))
+
+    df.select(upper($"v1")).collect
+  }
+
+  testAgainstSpark("upper with null") { securityLevel =>
+    val data = Seq(("lower", null.asInstanceOf[String]))
+
+    val df = makeDF(data, securityLevel, "v1", "v2")
+
+    df.select(upper($"v2")).collect
+  }
+
+  testAgainstSpark("vector sum") { securityLevel =>
+    val data: Seq[(Array[Double], Double)] = Seq(
+      (Array[Double](1.0, 2.0, 3.0), 4.0),
+      (Array[Double](5.0, 7.0, 7.0), 8.0))
+    val schema = StructType(Seq(
+      StructField("v", DataTypes.createArrayType(DoubleType)),
+      StructField("c", DoubleType)))
+
+    val df = securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema))
+
+    val vectorsum = new VectorSum
+    df.groupBy().agg(vectorsum($"v")).collect
+  }
+
+  testAgainstSpark("create array") { securityLevel =>
+    val data: Seq[(Double, Double)] = Seq(
+      (1.0, 2.0),
+      (3.0, 4.0))
+    val schema = StructType(Seq(
+      StructField("x1", DoubleType),
+      StructField("x2", DoubleType)))
+
+    val df = securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema))
+
+    df.select(array($"x1", $"x2").as("x")).collect
+  }
+
+  testAgainstSpark("limit with fewer returned values") { securityLevel =>
+    val data = Random.shuffle(for (i <- 0 until 256) yield (i, abc(i)))
+    val schema = StructType(Seq(
+      StructField("id", IntegerType),
+      StructField("word", StringType)))
+    val df = securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema))
+    df.sort($"id").limit(5).collect
+  }
+
+  testAgainstSpark("limit with more returned values") { securityLevel =>
+    val data = Random.shuffle(for (i <- 0 until 256) yield (i, abc(i)))
+    val schema = StructType(Seq(
+      StructField("id", IntegerType),
+      StructField("word", StringType)))
+    val df = securityLevel.applyTo(
+      spark.createDataFrame(
+        spark.sparkContext.makeRDD(data.map(Row.fromTuple), numPartitions),
+        schema))
+    df.sort($"id").limit(200).collect
+  }
+
+  testAgainstSpark("least squares") { securityLevel =>
+    LeastSquares.query(spark, securityLevel, "tiny", numPartitions).collect
+  }
+
+  testAgainstSpark("logistic regression") { securityLevel =>
+    LogisticRegression.train(spark, securityLevel, 1000, numPartitions)
+  }
+
+  testAgainstSpark("k-means") { securityLevel =>
+    import scala.math.Ordering.Implicits.seqDerivedOrdering
+    KMeans.train(spark, securityLevel, numPartitions, 10, 2, 3, 0.01).map(_.toSeq).sorted
+  }
+
+  testAgainstSpark("pagerank") { securityLevel =>
+    PageRank.run(spark, securityLevel, "256", numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 9") { securityLevel =>
+    TPCH.tpch9(spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("big data 1") { securityLevel =>
+    BigDataBenchmark.q1(spark, securityLevel, "tiny", numPartitions).collect
+  }
+
+  testAgainstSpark("big data 2") { securityLevel =>
+    BigDataBenchmark.q2(spark, securityLevel, "tiny", numPartitions).collect
+      .map { case Row(a: String, b: Double) => (a, b.toFloat) }
+      .sortBy(_._1)
+  }
+
+  testAgainstSpark("big data 3") { securityLevel =>
+    BigDataBenchmark.q3(spark, securityLevel, "tiny", numPartitions).collect
+  }
 
   def makeDF[A <: Product : scala.reflect.ClassTag : scala.reflect.runtime.universe.TypeTag](
     data: Seq[A], securityLevel: SecurityLevel, columnNames: String*): DataFrame =

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -339,8 +339,8 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
     val data = for (i <- 0 until 256) yield (i, abc(i), i.toDouble)
     val words = makeDF(data, securityLevel, "id", "category", "price")
 
-    val result = words.groupBy("category").agg(avg("price"))
-    result.collect.sortBy { case Row(category: String, _) => category }
+    words.groupBy("category").agg(avg("price").as("avgPrice"))
+      .collect.sortBy { case Row(category: String, _) => category }
   }
 
   testAgainstSpark("aggregate count") { securityLevel =>


### PR DESCRIPTION
This PR transitions Opaque operator matching from the logical level to the physical level. This change is important in supporting subqueries in the future because it allows Spark to apply logical rules for such queries. 