### PR TITLE
TPC-H test suite added

### DIFF
--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -148,8 +148,8 @@ class TPCH(
   val size: String,
   val numPartitions: Int,
 
-  val mapDF: Map[String, DataFrame],
-  val encryptedMapDF: Map[String, DataFrame],
+  val nameToDF: Map[String, DataFrame],
+  val nameToEncryptedDF: Map[String, DataFrame],
 ) {
 
   val tableNames = Seq("part", "supplier", "lineitem", "partsupp", "orders", "nation")
@@ -180,10 +180,10 @@ class TPCH(
 
   def ensureCached() = {
     for (name <- tableNames) {
-      mapDF.get(name).foreach(df =>
+      nameToDF.get(name).foreach(df =>
         Utils.ensureCached(df)
       )
-      encryptedMapDF.get(name).foreach(df =>
+      nameToEncryptedDF.get(name).foreach(df =>
         Utils.ensureCached(df)
       )
     }
@@ -195,12 +195,12 @@ class TPCH(
 
     securityLevel match {
       case Insecure => {
-        for ((name, df) <- mapDF) {
+        for ((name, df) <- nameToDF) {
           df.createOrReplaceTempView(name)
         }
       }
       case Encrypted => {
-        for ((name, df) <- encryptedMapDF) {
+        for ((name, df) <- nameToEncryptedDF) {
           df.createOrReplaceTempView(name)
         }
       }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -18,11 +18,13 @@
 package edu.berkeley.cs.rise.opaque.benchmark
 
 import java.io.File
+import scala.io.Source
 
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.util.fileToString
+import org.apache.spark.sql.catalyst.util.resourceToString
 
 object TPCH {
   def part(
@@ -176,8 +178,7 @@ object TPCH {
 
   def performQuery(queryNumber: Int, sqlContext: SQLContext) : DataFrame = {
     val queryLocation = sys.env.getOrElse("OPAQUE_HOME", ".") + "/src/test/resources/tpch/"
-    val sqlStr = fileToString(new File(Thread.currentThread().getContextClassLoader
-      .getResource(queryLocation + s"q$queryNumber.sql").getFile))
+    val sqlStr = Source.fromFile(queryLocation + s"q$queryNumber.sql").getLines().mkString("\n")
 
     sqlContext.sparkSession.sql(sqlStr)
   }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -138,7 +138,7 @@ object TPCH {
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/nation.tbl")
       .repartition(numPartitions))
-      .createOrReplaceTempView("nation " + securityLevel.name)
+      .createOrReplaceTempView("nation")
 
   def loadTables(
     sqlContext: SQLContext,

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -141,6 +141,39 @@ object TPCHDataFrames {
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/nation.tbl")
       .repartition(numPartitions))
+
+  def region(
+      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
+      : DataFrame =
+    securityLevel.applyTo(
+      sqlContext.read.schema(
+      StructType(Seq(
+        StructField("r_regionkey", IntegerType),
+        StructField("r_name", StringType),
+        StructField("r_comment", StringType))))
+      .format("csv")
+      .option("delimiter", "|")
+      .load(s"${Benchmark.dataDir}/tpch/$size/region.tbl")
+      .repartition(numPartitions))
+
+  def customer(
+      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
+      : DataFrame =
+    securityLevel.applyTo(
+      sqlContext.read.schema(
+      StructType(Seq(
+        StructField("c_custkey", IntegerType),
+        StructField("c_name", StringType),
+        StructField("c_address", StringType),
+        StructField("c_nationkey", IntegerType),
+        StructField("c_phone", StringType),
+        StructField("c_accbal", FloatType),
+        StructField("c_mktsegment", StringType),
+        StructField("c_comment", StringType))))
+      .format("csv")
+      .option("delimiter", "|")
+      .load(s"${Benchmark.dataDir}/tpch/$size/customer.tbl")
+      .repartition(numPartitions))
 }
 
 class TPCH(

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -27,9 +27,8 @@ import edu.berkeley.cs.rise.opaque.Utils
 
 object TPCHDataFrames {
   def part(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
+      sqlContext: SQLContext, size: String)
       : DataFrame =
-    securityLevel.applyTo(
       sqlContext.read.schema(
        StructType(Seq(
          StructField("p_partkey", IntegerType),
@@ -44,12 +43,10 @@ object TPCHDataFrames {
        .format("csv")
        .option("delimiter", "|")
        .load(s"${Benchmark.dataDir}/tpch/$size/part.tbl")
-       .repartition(numPartitions))
 
   def supplier(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
+      sqlContext: SQLContext, size: String)
       : DataFrame =
-    securityLevel.applyTo(
       sqlContext.read.schema(
        StructType(Seq(
          StructField("s_suppkey", IntegerType),
@@ -62,12 +59,10 @@ object TPCHDataFrames {
        .format("csv")
        .option("delimiter", "|")
        .load(s"${Benchmark.dataDir}/tpch/$size/supplier.tbl")
-       .repartition(numPartitions))
 
   def lineitem(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
+      sqlContext: SQLContext, size: String)
       : DataFrame =
-    securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
         StructField("l_orderkey", IntegerType),
@@ -89,12 +84,10 @@ object TPCHDataFrames {
       .format("csv")
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/lineitem.tbl")
-       .repartition(numPartitions))
 
   def partsupp(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
+      sqlContext: SQLContext, size: String)
       : DataFrame =
-    securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
         StructField("ps_partkey", IntegerType),
@@ -105,12 +98,10 @@ object TPCHDataFrames {
       .format("csv")
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/partsupp.tbl")
-      .repartition(numPartitions))
 
   def orders(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
+      sqlContext: SQLContext, size: String)
       : DataFrame =
-    securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
         StructField("o_orderkey", IntegerType),
@@ -125,12 +116,10 @@ object TPCHDataFrames {
       .format("csv")
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/orders.tbl")
-      .repartition(numPartitions))
 
   def nation(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
+      sqlContext: SQLContext, size: String)
       : DataFrame =
-    securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
         StructField("n_nationkey", IntegerType),
@@ -140,12 +129,10 @@ object TPCHDataFrames {
       .format("csv")
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/nation.tbl")
-      .repartition(numPartitions))
 
   def region(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
+      sqlContext: SQLContext, size: String)
       : DataFrame =
-    securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
         StructField("r_regionkey", IntegerType),
@@ -154,12 +141,10 @@ object TPCHDataFrames {
       .format("csv")
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/region.tbl")
-      .repartition(numPartitions))
 
   def customer(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
+      sqlContext: SQLContext, size: String)
       : DataFrame =
-    securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
         StructField("c_custkey", IntegerType),
@@ -173,19 +158,18 @@ object TPCHDataFrames {
       .format("csv")
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/customer.tbl")
-      .repartition(numPartitions))
 
   def generateMap(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
+      sqlContext: SQLContext, size: String)
       : Map[String, DataFrame] = {
-    Map("part" -> TPCHDataFrames.part(sqlContext, securityLevel, size, numPartitions),
-    "supplier" -> TPCHDataFrames.supplier(sqlContext, securityLevel, size, numPartitions),
-    "lineitem" -> TPCHDataFrames.lineitem(sqlContext, securityLevel, size, numPartitions),
-    "partsupp" -> TPCHDataFrames.partsupp(sqlContext, securityLevel, size, numPartitions),
-    "orders" -> TPCHDataFrames.orders(sqlContext, securityLevel, size, numPartitions),
-    "nation" -> TPCHDataFrames.nation(sqlContext, securityLevel, size, numPartitions),
-    "region" -> TPCHDataFrames.region(sqlContext, securityLevel, size, numPartitions),
-    "customer" -> TPCHDataFrames.customer(sqlContext, securityLevel, size, numPartitions)
+    Map("part" -> TPCHDataFrames.part(sqlContext, size),
+    "supplier" -> TPCHDataFrames.supplier(sqlContext, size),
+    "lineitem" -> TPCHDataFrames.lineitem(sqlContext, size),
+    "partsupp" -> TPCHDataFrames.partsupp(sqlContext, size),
+    "orders" -> TPCHDataFrames.orders(sqlContext, size),
+    "nation" -> TPCHDataFrames.nation(sqlContext, size),
+    "region" -> TPCHDataFrames.region(sqlContext, size),
+    "customer" -> TPCHDataFrames.customer(sqlContext, size)
     ),
   }
 }
@@ -193,10 +177,8 @@ object TPCHDataFrames {
 class TPCH(
   val sqlContext: SQLContext,
   val size: String,
-  val numPartitions: Int,
 
   val nameToDF: Map[String, DataFrame],
-  val nameToEncryptedDF: Map[String, DataFrame],
 ) {
 
   val tableNames = Seq("part", "supplier", "lineitem", "partsupp", "orders", "nation", "region", "customer")
@@ -204,41 +186,27 @@ class TPCH(
   def this(
     sqlContext: SQLContext,
     size: String,
-    numPartitions: Int,
   ) = {
-    this(sqlContext, size, numPartitions, 
-        TPCHDataFrames.generateMap(sqlContext, Insecure, size, numPartitions),
-        TPCHDataFrames.generateMap(sqlContext, Encrypted, size, numPartitions))
+    this(sqlContext, size, TPCHDataFrames.generateMap(sqlContext, size))
   }
 
   def ensureCached() = {
     for (name <- tableNames) {
-      nameToDF.get(name).foreach(df =>
+      nameToDF.get(name).foreach(df => {
         Utils.ensureCached(df)
-      )
-      nameToEncryptedDF.get(name).foreach(df =>
-        Utils.ensureCached(df)
-      )
+        Utils.ensureCached(Encrypted.applyTo(df))
+      })
     }
   }
 
-  def setupViews(securityLevel: SecurityLevel) = {
-    securityLevel match {
-      case Insecure => {
-        for ((name, df) <- nameToDF) {
-          df.createOrReplaceTempView(name)
-        }
-      }
-      case Encrypted => {
-        for ((name, df) <- nameToEncryptedDF) {
-          df.createOrReplaceTempView(name)
-        }
-      }
+  def setupViews(securityLevel: SecurityLevel, numPartitions: Int) = {
+    for ((name, df) <- nameToDF) {
+      securityLevel.applyTo(df.repartition(numPartitions)).createOrReplaceTempView(name)
     }
   }
 
-  def query(queryNumber: Int, securityLevel: SecurityLevel, sqlContext: SQLContext) : DataFrame = {
-    setupViews(securityLevel)
+  def query(queryNumber: Int, securityLevel: SecurityLevel, sqlContext: SQLContext, numPartitions: Int) : DataFrame = {
+    setupViews(securityLevel, numPartitions)
 
     val queryLocation = sys.env.getOrElse("OPAQUE_HOME", ".") + "/src/test/resources/tpch/"
     val sqlStr = Source.fromFile(queryLocation + s"q$queryNumber.sql").getLines().mkString("\n")

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -138,32 +138,33 @@ object TPCH {
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/nation.tbl")
       .repartition(numPartitions))
-      .createOrReplaceTempView("nation")
+      .createOrReplaceTempView("nation " + securityLevel.name)
 
   def loadTables(
-    queryNumber: Int,
     sqlContext: SQLContext,
-    securityLevel: SecurityLevel,
     size: String,
     numPartitions: Int) = {
 
-    queryNumber match {
-      case 9 => {
-        part(sqlContext, securityLevel, size, numPartitions)
-        supplier(sqlContext, securityLevel, size, numPartitions)
-        lineitem(sqlContext, securityLevel, size, numPartitions)
-        partsupp(sqlContext, securityLevel, size, numPartitions)
-        orders(sqlContext, securityLevel, size, numPartitions)
-        nation(sqlContext, securityLevel, size, numPartitions)
-      }
-    }
+      part(sqlContext, Insecure, size, numPartitions)
+      supplier(sqlContext, Insecure, size, numPartitions)
+      lineitem(sqlContext, Insecure, size, numPartitions)
+      partsupp(sqlContext, Insecure, size, numPartitions)
+      orders(sqlContext, Insecure, size, numPartitions)
+      nation(sqlContext, Insecure, size, numPartitions)
+
+      part(sqlContext, Encrypted, size, numPartitions)
+      supplier(sqlContext, Encrypted, size, numPartitions)
+      lineitem(sqlContext, Encrypted, size, numPartitions)
+      partsupp(sqlContext, Encrypted, size, numPartitions)
+      orders(sqlContext, Encrypted, size, numPartitions)
+      nation(sqlContext, Encrypted, size, numPartitions)
   }
 
   def clearTables(sqlContext: SQLContext) = {
-    val tableNames = Seq("part", "supplier", "lineitem", "partsupp", "orders", "nation")
+    val partialNames = Seq("part", "supplier", "lineitem", "partsupp", "orders", "nation")
 
-    for (tableName <- tableNames) {
-      sqlContext.sql(s"""DROP TABLE IF EXISTS default.${tableName}""".stripMargin)
+    for (partialName <- partialNames) {
+      sqlContext.sql(s"""DROP TABLE IF EXISTS default.${partialName}""".stripMargin)
     }
   }
 
@@ -181,7 +182,6 @@ object TPCH {
     size: String,
     numPartitions: Int) : DataFrame = {
 
-    loadTables(queryNumber, sqlContext, securityLevel, size, numPartitions)
     val df = performQuery(queryNumber, sqlContext)
     clearTables(sqlContext)
 

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -155,7 +155,7 @@ object TPCH {
         StructField("c_address", StringType),
         StructField("c_nationkey", IntegerType),
         StructField("c_phone", StringType),
-        StructField("c_accbal", FloatType),
+        StructField("c_acctbal", FloatType),
         StructField("c_mktsegment", StringType),
         StructField("c_comment", StringType))))
       .format("csv")

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -17,11 +17,12 @@
 
 package edu.berkeley.cs.rise.opaque.benchmark
 
+import java.io.File
+
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.catalyst.util.resourceToString
+import org.apache.spark.sql.catalyst.util.fileToString
 
 object TPCH {
   def part(
@@ -174,9 +175,9 @@ object TPCH {
   }
 
   def performQuery(queryNumber: Int, sqlContext: SQLContext) : DataFrame = {
-    val queryLocation = "../../../../../../../../test/resources/tpch/"
-    val sqlStr = resourceToString(queryLocation + s"q$queryNumber.sql",
-      classLoader = Thread.currentThread().getContextClassLoader)
+    val queryLocation = sys.env.getOrElse("OPAQUE_HOME", ".") + "/src/test/resources/tpch/"
+    val sqlStr = fileToString(new File(Thread.currentThread().getContextClassLoader
+      .getResource(queryLocation + s"q$queryNumber.sql").getFile))
 
     sqlContext.sparkSession.sql(sqlStr)
   }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.SQLContext
 object TPCH {
   def part(
       sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : DataFrame =
+      : Unit =
     securityLevel.applyTo(
       sqlContext.read.schema(
        StructType(Seq(
@@ -42,10 +42,11 @@ object TPCH {
        .option("delimiter", "|")
        .load(s"${Benchmark.dataDir}/tpch/$size/part.tbl")
        .repartition(numPartitions))
+       .createOrReplaceTempView("part")
 
   def supplier(
       sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : DataFrame =
+      : Unit =
     securityLevel.applyTo(
       sqlContext.read.schema(
        StructType(Seq(
@@ -60,10 +61,11 @@ object TPCH {
        .option("delimiter", "|")
        .load(s"${Benchmark.dataDir}/tpch/$size/supplier.tbl")
        .repartition(numPartitions))
+       .createOrReplaceTempView("supplier")
 
   def lineitem(
       sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : DataFrame =
+      : Unit =
     securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
@@ -86,11 +88,12 @@ object TPCH {
       .format("csv")
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/lineitem.tbl")
-       .repartition(numPartitions))
+      .repartition(numPartitions))
+      .createOrReplaceTempView("lineitem")
 
   def partsupp(
       sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : DataFrame =
+      : Unit =
     securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
@@ -103,10 +106,11 @@ object TPCH {
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/partsupp.tbl")
       .repartition(numPartitions))
+      .createOrReplaceTempView("partsupp")
 
   def orders(
       sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : DataFrame =
+      : Unit =
     securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
@@ -123,10 +127,11 @@ object TPCH {
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/orders.tbl")
       .repartition(numPartitions))
+      .createOrReplaceTempView("orders")
 
   def nation(
       sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : DataFrame =
+      : Unit =
     securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
@@ -138,6 +143,7 @@ object TPCH {
       .option("delimiter", "|")
       .load(s"${Benchmark.dataDir}/tpch/$size/nation.tbl")
       .repartition(numPartitions))
+      .createOrReplaceTempView("nation")
 
 
   private def tpch9EncryptedDFs(

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -25,7 +25,10 @@ import org.apache.spark.sql.SQLContext
 
 import edu.berkeley.cs.rise.opaque.Utils
 
-object TPCHDataFrames {
+object TPCH {
+
+  val tableNames = Seq("part", "supplier", "lineitem", "partsupp", "orders", "nation", "region", "customer")
+
   def part(
       sqlContext: SQLContext, size: String)
       : DataFrame =
@@ -162,33 +165,30 @@ object TPCHDataFrames {
   def generateMap(
       sqlContext: SQLContext, size: String)
       : Map[String, DataFrame] = {
-    Map("part" -> TPCHDataFrames.part(sqlContext, size),
-    "supplier" -> TPCHDataFrames.supplier(sqlContext, size),
-    "lineitem" -> TPCHDataFrames.lineitem(sqlContext, size),
-    "partsupp" -> TPCHDataFrames.partsupp(sqlContext, size),
-    "orders" -> TPCHDataFrames.orders(sqlContext, size),
-    "nation" -> TPCHDataFrames.nation(sqlContext, size),
-    "region" -> TPCHDataFrames.region(sqlContext, size),
-    "customer" -> TPCHDataFrames.customer(sqlContext, size)
+    Map("part" -> part(sqlContext, size),
+    "supplier" -> supplier(sqlContext, size),
+    "lineitem" -> lineitem(sqlContext, size),
+    "partsupp" -> partsupp(sqlContext, size),
+    "orders" -> orders(sqlContext, size),
+    "nation" -> nation(sqlContext, size),
+    "region" -> region(sqlContext, size),
+    "customer" -> customer(sqlContext, size)
     ),
+  }
+
+  def apply(sqlContext: SQLContext, size: String) : TPCH = {
+    val tpch = new TPCH(sqlContext, size)
+    tpch.tableNames = tableNames
+    tpch.nameToDF = generateMap(sqlContext, size)
+    tpch.ensureCached()
+    tpch
   }
 }
 
-class TPCH(
-  val sqlContext: SQLContext,
-  val size: String,
+class TPCH(val sqlContext: SQLContext, val size: String) {
 
-  val nameToDF: Map[String, DataFrame],
-) {
-
-  val tableNames = Seq("part", "supplier", "lineitem", "partsupp", "orders", "nation", "region", "customer")
-
-  def this(
-    sqlContext: SQLContext,
-    size: String,
-  ) = {
-    this(sqlContext, size, TPCHDataFrames.generateMap(sqlContext, size))
-  }
+  var tableNames : Seq[String] = Seq()
+  var nameToDF : Map[String, DataFrame] = Map()
 
   def ensureCached() = {
     for (name <- tableNames) {

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -150,8 +150,25 @@ object TPCH {
     sqlContext: SQLContext,
     securityLevel: SecurityLevel,
     size: String,
-    numPartitions: Int,
-    quantityThreshold: Option[Int] = None) : Unit = {
+    numPartitions: Int) : Unit = {
+
+    queryNumber match {
+      case 9 => {
+        part(sqlContext, securityLevel, size, numPartitions)
+        supplier(sqlContext, securityLevel, size, numPartitions)
+        lineitem(sqlContext, securityLevel, size, numPartitions)
+        partsupp(sqlContext, securityLevel, size, numPartitions)
+        orders(sqlContext, securityLevel, size, numPartitions)
+        nation(sqlContext, securityLevel, size, numPartitions)
+      }
+    }
+  }
+
+  def clearTables() = {
+    tableNames = Seq("part", "supplier", "lineitem", "partsupp", "orders", "nation")
+
+    for (tableName <- tableNames) {
+      spark.sql(s"""DROP TABLE IF EXISTS default.${tableName}""".stripMargin)
   }
 
   def tpch(
@@ -161,7 +178,7 @@ object TPCH {
     size: String,
     numPartitions: Int) : DataFrame = {
 
-    loadTables(queryNumber, sqlContext, securityLevel, size, numPartitions, quantityThreshold)
+    loadTables(queryNumber, sqlContext, securityLevel, size, numPartitions)
     val df = performQuery()
     clearTables()
     df

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -23,13 +23,10 @@ import scala.io.Source
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.catalyst.util.fileToString
-import org.apache.spark.sql.catalyst.util.resourceToString
 
 object TPCH {
   def part(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : Unit =
+      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int) =
     securityLevel.applyTo(
       sqlContext.read.schema(
        StructType(Seq(
@@ -49,8 +46,7 @@ object TPCH {
        .createOrReplaceTempView("part")
 
   def supplier(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : Unit =
+      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int) =
     securityLevel.applyTo(
       sqlContext.read.schema(
        StructType(Seq(
@@ -68,8 +64,7 @@ object TPCH {
        .createOrReplaceTempView("supplier")
 
   def lineitem(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : Unit =
+      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int) =
     securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
@@ -96,8 +91,7 @@ object TPCH {
       .createOrReplaceTempView("lineitem")
 
   def partsupp(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : Unit =
+      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int) =
     securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
@@ -113,8 +107,7 @@ object TPCH {
       .createOrReplaceTempView("partsupp")
 
   def orders(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : Unit =
+      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int) =
     securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
@@ -134,8 +127,7 @@ object TPCH {
       .createOrReplaceTempView("orders")
 
   def nation(
-      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int)
-      : Unit =
+      sqlContext: SQLContext, securityLevel: SecurityLevel, size: String, numPartitions: Int) =
     securityLevel.applyTo(
       sqlContext.read.schema(
       StructType(Seq(
@@ -154,7 +146,7 @@ object TPCH {
     sqlContext: SQLContext,
     securityLevel: SecurityLevel,
     size: String,
-    numPartitions: Int) : Unit = {
+    numPartitions: Int) = {
 
     queryNumber match {
       case 9 => {
@@ -168,7 +160,7 @@ object TPCH {
     }
   }
 
-  def clearTables(sqlContext: SQLContext) : Unit = {
+  def clearTables(sqlContext: SQLContext) = {
     val tableNames = Seq("part", "supplier", "lineitem", "partsupp", "orders", "nation")
 
     for (tableName <- tableNames) {

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.catalyst.util.resourceToString
 
 object TPCH {
   def part(
@@ -172,6 +173,14 @@ object TPCH {
     }
   }
 
+  def performQuery(queryNumber: Int, sqlContext: SQLContext) : DataFrame = {
+    val queryLocation = "../../../../../../../../test/resources/tpch/"
+    val sqlStr = resourceToString(queryLocation + s"q$queryNumber.sql",
+      classLoader = Thread.currentThread().getContextClassLoader)
+
+    sqlContext.sparkSession.sql(sqlStr)
+  }
+
   def tpch(
     queryNumber: Int,
     sqlContext: SQLContext,
@@ -180,8 +189,9 @@ object TPCH {
     numPartitions: Int) : DataFrame = {
 
     loadTables(queryNumber, sqlContext, securityLevel, size, numPartitions)
-    val df = performQuery()
-    clearTables()
+    val df = performQuery(queryNumber, sqlContext)
+    clearTables(sqlContext)
+
     df
   }
 }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -164,11 +164,12 @@ object TPCH {
     }
   }
 
-  def clearTables() = {
-    tableNames = Seq("part", "supplier", "lineitem", "partsupp", "orders", "nation")
+  def clearTables(sqlContext: SQLContext) : Unit = {
+    val tableNames = Seq("part", "supplier", "lineitem", "partsupp", "orders", "nation")
 
     for (tableName <- tableNames) {
-      spark.sql(s"""DROP TABLE IF EXISTS default.${tableName}""".stripMargin)
+      sqlContext.sql(s"""DROP TABLE IF EXISTS default.${tableName}""".stripMargin)
+    }
   }
 
   def tpch(

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCH.scala
@@ -17,7 +17,6 @@
 
 package edu.berkeley.cs.rise.opaque.benchmark
 
-import java.io.File
 import scala.io.Source
 
 import org.apache.spark.sql.DataFrame

--- a/src/test/resources/tpch/q1.sql
+++ b/src/test/resources/tpch/q1.sql
@@ -1,0 +1,23 @@
+-- using default substitutions
+
+select
+	l_returnflag,
+	l_linestatus,
+	sum(l_quantity) as sum_qty,
+	sum(l_extendedprice) as sum_base_price,
+	sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+	sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+	avg(l_quantity) as avg_qty,
+	avg(l_extendedprice) as avg_price,
+	avg(l_discount) as avg_disc,
+	count(*) as count_order
+from
+	lineitem
+where
+	l_shipdate <= date '1998-12-01' - interval '90' day
+group by
+	l_returnflag,
+	l_linestatus
+order by
+	l_returnflag,
+	l_linestatus

--- a/src/test/resources/tpch/q10.sql
+++ b/src/test/resources/tpch/q10.sql
@@ -1,0 +1,34 @@
+-- using default substitutions
+
+select
+	c_custkey,
+	c_name,
+	sum(l_extendedprice * (1 - l_discount)) as revenue,
+	c_acctbal,
+	n_name,
+	c_address,
+	c_phone,
+	c_comment
+from
+	customer,
+	orders,
+	lineitem,
+	nation
+where
+	c_custkey = o_custkey
+	and l_orderkey = o_orderkey
+	and o_orderdate >= date '1993-10-01'
+	and o_orderdate < date '1993-10-01' + interval '3' month
+	and l_returnflag = 'R'
+	and c_nationkey = n_nationkey
+group by
+	c_custkey,
+	c_name,
+	c_acctbal,
+	c_phone,
+	n_name,
+	c_address,
+	c_comment
+order by
+	revenue desc
+limit 20

--- a/src/test/resources/tpch/q11.sql
+++ b/src/test/resources/tpch/q11.sql
@@ -1,0 +1,29 @@
+-- using default substitutions
+
+select
+	ps_partkey,
+	sum(ps_supplycost * ps_availqty) as value
+from
+	partsupp,
+	supplier,
+	nation
+where
+	ps_suppkey = s_suppkey
+	and s_nationkey = n_nationkey
+	and n_name = 'GERMANY'
+group by
+	ps_partkey having
+		sum(ps_supplycost * ps_availqty) > (
+			select
+				sum(ps_supplycost * ps_availqty) * 0.0001000000
+			from
+				partsupp,
+				supplier,
+				nation
+			where
+				ps_suppkey = s_suppkey
+				and s_nationkey = n_nationkey
+				and n_name = 'GERMANY'
+		)
+order by
+	value desc

--- a/src/test/resources/tpch/q12.sql
+++ b/src/test/resources/tpch/q12.sql
@@ -1,0 +1,30 @@
+-- using default substitutions
+
+select
+	l_shipmode,
+	sum(case
+		when o_orderpriority = '1-URGENT'
+			or o_orderpriority = '2-HIGH'
+			then 1
+		else 0
+	end) as high_line_count,
+	sum(case
+		when o_orderpriority <> '1-URGENT'
+			and o_orderpriority <> '2-HIGH'
+			then 1
+		else 0
+	end) as low_line_count
+from
+	orders,
+	lineitem
+where
+	o_orderkey = l_orderkey
+	and l_shipmode in ('MAIL', 'SHIP')
+	and l_commitdate < l_receiptdate
+	and l_shipdate < l_commitdate
+	and l_receiptdate >= date '1994-01-01'
+	and l_receiptdate < date '1994-01-01' + interval '1' year
+group by
+	l_shipmode
+order by
+	l_shipmode

--- a/src/test/resources/tpch/q13.sql
+++ b/src/test/resources/tpch/q13.sql
@@ -1,0 +1,22 @@
+-- using default substitutions
+
+select
+	c_count,
+	count(*) as custdist
+from
+	(
+		select
+			c_custkey,
+			count(o_orderkey) as c_count
+		from
+			customer left outer join orders on
+				c_custkey = o_custkey
+				and o_comment not like '%special%requests%'
+		group by
+			c_custkey
+	) as c_orders
+group by
+	c_count
+order by
+	custdist desc,
+	c_count desc

--- a/src/test/resources/tpch/q14.sql
+++ b/src/test/resources/tpch/q14.sql
@@ -1,0 +1,15 @@
+-- using default substitutions
+
+select
+	100.00 * sum(case
+		when p_type like 'PROMO%'
+			then l_extendedprice * (1 - l_discount)
+		else 0
+	end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+from
+	lineitem,
+	part
+where
+	l_partkey = p_partkey
+	and l_shipdate >= date '1995-09-01'
+	and l_shipdate < date '1995-09-01' + interval '1' month

--- a/src/test/resources/tpch/q15.sql
+++ b/src/test/resources/tpch/q15.sql
@@ -1,0 +1,35 @@
+-- using default substitutions
+
+with revenue0 as
+	(select
+		l_suppkey as supplier_no,
+		sum(l_extendedprice * (1 - l_discount)) as total_revenue
+	from
+		lineitem
+	where
+		l_shipdate >= date '1996-01-01'
+		and l_shipdate < date '1996-01-01' + interval '3' month
+	group by
+		l_suppkey)
+
+
+select
+	s_suppkey,
+	s_name,
+	s_address,
+	s_phone,
+	total_revenue
+from
+	supplier,
+	revenue0
+where
+	s_suppkey = supplier_no
+	and total_revenue = (
+		select
+			max(total_revenue)
+		from
+			revenue0
+	)
+order by
+	s_suppkey
+

--- a/src/test/resources/tpch/q16.sql
+++ b/src/test/resources/tpch/q16.sql
@@ -1,0 +1,32 @@
+-- using default substitutions
+
+select
+	p_brand,
+	p_type,
+	p_size,
+	count(distinct ps_suppkey) as supplier_cnt
+from
+	partsupp,
+	part
+where
+	p_partkey = ps_partkey
+	and p_brand <> 'Brand#45'
+	and p_type not like 'MEDIUM POLISHED%'
+	and p_size in (49, 14, 23, 45, 19, 3, 36, 9)
+	and ps_suppkey not in (
+		select
+			s_suppkey
+		from
+			supplier
+		where
+			s_comment like '%Customer%Complaints%'
+	)
+group by
+	p_brand,
+	p_type,
+	p_size
+order by
+	supplier_cnt desc,
+	p_brand,
+	p_type,
+	p_size

--- a/src/test/resources/tpch/q17.sql
+++ b/src/test/resources/tpch/q17.sql
@@ -1,0 +1,19 @@
+-- using default substitutions
+
+select
+	sum(l_extendedprice) / 7.0 as avg_yearly
+from
+	lineitem,
+	part
+where
+	p_partkey = l_partkey
+	and p_brand = 'Brand#23'
+	and p_container = 'MED BOX'
+	and l_quantity < (
+		select
+			0.2 * avg(l_quantity)
+		from
+			lineitem
+		where
+			l_partkey = p_partkey
+	)

--- a/src/test/resources/tpch/q18.sql
+++ b/src/test/resources/tpch/q18.sql
@@ -1,0 +1,35 @@
+-- using default substitutions
+
+select
+	c_name,
+	c_custkey,
+	o_orderkey,
+	o_orderdate,
+	o_totalprice,
+	sum(l_quantity)
+from
+	customer,
+	orders,
+	lineitem
+where
+	o_orderkey in (
+		select
+			l_orderkey
+		from
+			lineitem
+		group by
+			l_orderkey having
+				sum(l_quantity) > 300
+	)
+	and c_custkey = o_custkey
+	and o_orderkey = l_orderkey
+group by
+	c_name,
+	c_custkey,
+	o_orderkey,
+	o_orderdate,
+	o_totalprice
+order by
+	o_totalprice desc,
+	o_orderdate
+limit 100

--- a/src/test/resources/tpch/q19.sql
+++ b/src/test/resources/tpch/q19.sql
@@ -1,0 +1,37 @@
+-- using default substitutions
+
+select
+	sum(l_extendedprice* (1 - l_discount)) as revenue
+from
+	lineitem,
+	part
+where
+	(
+		p_partkey = l_partkey
+		and p_brand = 'Brand#12'
+		and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+		and l_quantity >= 1 and l_quantity <= 1 + 10
+		and p_size between 1 and 5
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)
+	or
+	(
+		p_partkey = l_partkey
+		and p_brand = 'Brand#23'
+		and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+		and l_quantity >= 10 and l_quantity <= 10 + 10
+		and p_size between 1 and 10
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)
+	or
+	(
+		p_partkey = l_partkey
+		and p_brand = 'Brand#34'
+		and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+		and l_quantity >= 20 and l_quantity <= 20 + 10
+		and p_size between 1 and 15
+		and l_shipmode in ('AIR', 'AIR REG')
+		and l_shipinstruct = 'DELIVER IN PERSON'
+	)

--- a/src/test/resources/tpch/q2.sql
+++ b/src/test/resources/tpch/q2.sql
@@ -1,0 +1,46 @@
+-- using default substitutions
+
+select
+	s_acctbal,
+	s_name,
+	n_name,
+	p_partkey,
+	p_mfgr,
+	s_address,
+	s_phone,
+	s_comment
+from
+	part,
+	supplier,
+	partsupp,
+	nation,
+	region
+where
+	p_partkey = ps_partkey
+	and s_suppkey = ps_suppkey
+	and p_size = 15
+	and p_type like '%BRASS'
+	and s_nationkey = n_nationkey
+	and n_regionkey = r_regionkey
+	and r_name = 'EUROPE'
+	and ps_supplycost = (
+		select
+			min(ps_supplycost)
+		from
+			partsupp,
+			supplier,
+			nation,
+			region
+		where
+			p_partkey = ps_partkey
+			and s_suppkey = ps_suppkey
+			and s_nationkey = n_nationkey
+			and n_regionkey = r_regionkey
+			and r_name = 'EUROPE'
+	)
+order by
+	s_acctbal desc,
+	n_name,
+	s_name,
+	p_partkey
+limit 100

--- a/src/test/resources/tpch/q20.sql
+++ b/src/test/resources/tpch/q20.sql
@@ -1,0 +1,39 @@
+-- using default substitutions
+
+select
+	s_name,
+	s_address
+from
+	supplier,
+	nation
+where
+	s_suppkey in (
+		select
+			ps_suppkey
+		from
+			partsupp
+		where
+			ps_partkey in (
+				select
+					p_partkey
+				from
+					part
+				where
+					p_name like 'forest%'
+			)
+			and ps_availqty > (
+				select
+					0.5 * sum(l_quantity)
+				from
+					lineitem
+				where
+					l_partkey = ps_partkey
+					and l_suppkey = ps_suppkey
+					and l_shipdate >= date '1994-01-01'
+					and l_shipdate < date '1994-01-01' + interval '1' year
+			)
+	)
+	and s_nationkey = n_nationkey
+	and n_name = 'CANADA'
+order by
+	s_name

--- a/src/test/resources/tpch/q21.sql
+++ b/src/test/resources/tpch/q21.sql
@@ -1,0 +1,42 @@
+-- using default substitutions
+
+select
+	s_name,
+	count(*) as numwait
+from
+	supplier,
+	lineitem l1,
+	orders,
+	nation
+where
+	s_suppkey = l1.l_suppkey
+	and o_orderkey = l1.l_orderkey
+	and o_orderstatus = 'F'
+	and l1.l_receiptdate > l1.l_commitdate
+	and exists (
+		select
+			*
+		from
+			lineitem l2
+		where
+			l2.l_orderkey = l1.l_orderkey
+			and l2.l_suppkey <> l1.l_suppkey
+	)
+	and not exists (
+		select
+			*
+		from
+			lineitem l3
+		where
+			l3.l_orderkey = l1.l_orderkey
+			and l3.l_suppkey <> l1.l_suppkey
+			and l3.l_receiptdate > l3.l_commitdate
+	)
+	and s_nationkey = n_nationkey
+	and n_name = 'SAUDI ARABIA'
+group by
+	s_name
+order by
+	numwait desc,
+	s_name
+limit 100

--- a/src/test/resources/tpch/q22.sql
+++ b/src/test/resources/tpch/q22.sql
@@ -1,0 +1,39 @@
+-- using default substitutions
+
+select
+	cntrycode,
+	count(*) as numcust,
+	sum(c_acctbal) as totacctbal
+from
+	(
+		select
+			substring(c_phone, 1, 2) as cntrycode,
+			c_acctbal
+		from
+			customer
+		where
+			substring(c_phone, 1, 2) in
+				('13', '31', '23', '29', '30', '18', '17')
+			and c_acctbal > (
+				select
+					avg(c_acctbal)
+				from
+					customer
+				where
+					c_acctbal > 0.00
+					and substring(c_phone, 1, 2) in
+						('13', '31', '23', '29', '30', '18', '17')
+			)
+			and not exists (
+				select
+					*
+				from
+					orders
+				where
+					o_custkey = c_custkey
+			)
+	) as custsale
+group by
+	cntrycode
+order by
+	cntrycode

--- a/src/test/resources/tpch/q3.sql
+++ b/src/test/resources/tpch/q3.sql
@@ -1,0 +1,25 @@
+-- using default substitutions
+
+select
+	l_orderkey,
+	sum(l_extendedprice * (1 - l_discount)) as revenue,
+	o_orderdate,
+	o_shippriority
+from
+	customer,
+	orders,
+	lineitem
+where
+	c_mktsegment = 'BUILDING'
+	and c_custkey = o_custkey
+	and l_orderkey = o_orderkey
+	and o_orderdate < date '1995-03-15'
+	and l_shipdate > date '1995-03-15'
+group by
+	l_orderkey,
+	o_orderdate,
+	o_shippriority
+order by
+	revenue desc,
+	o_orderdate
+limit 10

--- a/src/test/resources/tpch/q4.sql
+++ b/src/test/resources/tpch/q4.sql
@@ -1,0 +1,23 @@
+-- using default substitutions
+
+select
+	o_orderpriority,
+	count(*) as order_count
+from
+	orders
+where
+	o_orderdate >= date '1993-07-01'
+	and o_orderdate < date '1993-07-01' + interval '3' month
+	and exists (
+		select
+			*
+		from
+			lineitem
+		where
+			l_orderkey = o_orderkey
+			and l_commitdate < l_receiptdate
+	)
+group by
+	o_orderpriority
+order by
+	o_orderpriority

--- a/src/test/resources/tpch/q5.sql
+++ b/src/test/resources/tpch/q5.sql
@@ -1,0 +1,26 @@
+-- using default substitutions
+
+select
+	n_name,
+	sum(l_extendedprice * (1 - l_discount)) as revenue
+from
+	customer,
+	orders,
+	lineitem,
+	supplier,
+	nation,
+	region
+where
+	c_custkey = o_custkey
+	and l_orderkey = o_orderkey
+	and l_suppkey = s_suppkey
+	and c_nationkey = s_nationkey
+	and s_nationkey = n_nationkey
+	and n_regionkey = r_regionkey
+	and r_name = 'ASIA'
+	and o_orderdate >= date '1994-01-01'
+	and o_orderdate < date '1994-01-01' + interval '1' year
+group by
+	n_name
+order by
+	revenue desc

--- a/src/test/resources/tpch/q6.sql
+++ b/src/test/resources/tpch/q6.sql
@@ -1,0 +1,11 @@
+-- using default substitutions
+
+select
+	sum(l_extendedprice * l_discount) as revenue
+from
+	lineitem
+where
+	l_shipdate >= date '1994-01-01'
+	and l_shipdate < date '1994-01-01' + interval '1' year
+	and l_discount between .06 - 0.01 and .06 + 0.01
+	and l_quantity < 24

--- a/src/test/resources/tpch/q7.sql
+++ b/src/test/resources/tpch/q7.sql
@@ -1,0 +1,41 @@
+-- using default substitutions
+
+select
+	supp_nation,
+	cust_nation,
+	l_year,
+	sum(volume) as revenue
+from
+	(
+		select
+			n1.n_name as supp_nation,
+			n2.n_name as cust_nation,
+			year(l_shipdate) as l_year,
+			l_extendedprice * (1 - l_discount) as volume
+		from
+			supplier,
+			lineitem,
+			orders,
+			customer,
+			nation n1,
+			nation n2
+		where
+			s_suppkey = l_suppkey
+			and o_orderkey = l_orderkey
+			and c_custkey = o_custkey
+			and s_nationkey = n1.n_nationkey
+			and c_nationkey = n2.n_nationkey
+			and (
+				(n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
+				or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE')
+			)
+			and l_shipdate between date '1995-01-01' and date '1996-12-31'
+	) as shipping
+group by
+	supp_nation,
+	cust_nation,
+	l_year
+order by
+	supp_nation,
+	cust_nation,
+	l_year

--- a/src/test/resources/tpch/q8.sql
+++ b/src/test/resources/tpch/q8.sql
@@ -1,0 +1,39 @@
+-- using default substitutions
+
+select
+	o_year,
+	sum(case
+		when nation = 'BRAZIL' then volume
+		else 0
+	end) / sum(volume) as mkt_share
+from
+	(
+		select
+			year(o_orderdate) as o_year,
+			l_extendedprice * (1 - l_discount) as volume,
+			n2.n_name as nation
+		from
+			part,
+			supplier,
+			lineitem,
+			orders,
+			customer,
+			nation n1,
+			nation n2,
+			region
+		where
+			p_partkey = l_partkey
+			and s_suppkey = l_suppkey
+			and l_orderkey = o_orderkey
+			and o_custkey = c_custkey
+			and c_nationkey = n1.n_nationkey
+			and n1.n_regionkey = r_regionkey
+			and r_name = 'AMERICA'
+			and s_nationkey = n2.n_nationkey
+			and o_orderdate between date '1995-01-01' and date '1996-12-31'
+			and p_type = 'ECONOMY ANODIZED STEEL'
+	) as all_nations
+group by
+	o_year
+order by
+	o_year

--- a/src/test/resources/tpch/q9.sql
+++ b/src/test/resources/tpch/q9.sql
@@ -1,0 +1,34 @@
+-- using default substitutions
+
+select
+	nation,
+	o_year,
+	sum(amount) as sum_profit
+from
+	(
+		select
+			n_name as nation,
+			year(o_orderdate) as o_year,
+			l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+		from
+			part,
+			supplier,
+			lineitem,
+			partsupp,
+			orders,
+			nation
+		where
+			s_suppkey = l_suppkey
+			and ps_suppkey = l_suppkey
+			and ps_partkey = l_partkey
+			and p_partkey = l_partkey
+			and o_orderkey = l_orderkey
+			and s_nationkey = n_nationkey
+			and p_name like '%green%'
+	) as profit
+group by
+	nation,
+	o_year
+order by
+	nation,
+	o_year desc

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -808,9 +808,11 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
     PageRank.run(spark, securityLevel, "256", numPartitions).collect.toSet
   }
 
+  /*
   testAgainstSpark("TPC-H 9") { securityLevel =>
     TPCH.tpch(9, spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
   }
+  */
 
   testAgainstSpark("big data 1") { securityLevel =>
     BigDataBenchmark.q1(spark, securityLevel, "tiny", numPartitions).collect

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -32,9 +32,6 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.unsafe.types.CalendarInterval
-import org.scalactic.TolerantNumerics
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.FunSuite
 
 import edu.berkeley.cs.rise.opaque.benchmark._
 import edu.berkeley.cs.rise.opaque.execution.EncryptedBlockRDDScanExec
@@ -42,27 +39,12 @@ import edu.berkeley.cs.rise.opaque.expressions.DotProduct.dot
 import edu.berkeley.cs.rise.opaque.expressions.VectorMultiply.vectormultiply
 import edu.berkeley.cs.rise.opaque.expressions.VectorSum
 
-trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll with TestUtils { self =>
+trait OpaqueOperatorTests extends TestUtils { self =>
 
-  def spark: SparkSession
-  def numPartitions: Int
-
-  protected object testImplicits extends SQLImplicits {
-    protected override def _sqlContext: SQLContext = self.spark.sqlContext
-  }
-  import testImplicits._
-
-  override def beforeAll(): Unit = {
-    Utils.initSQLContext(spark.sqlContext)
-  }
-
-  override def afterAll(): Unit = {
-    spark.stop()
-  }
-
-  // Modify the behavior of === for Double and Array[Double] to use a numeric tolerance
-  implicit val tolerantDoubleEquality = TolerantNumerics.tolerantDoubleEquality(1e-6)
-  implicit val tolerantDoubleArrayEquality = equalityToArrayEquality[Double]
+    protected object testImplicits extends SQLImplicits {
+      protected override def _sqlContext: SQLContext = self.spark.sqlContext
+    }
+    import testImplicits._
 
     /** Modified from https://stackoverflow.com/questions/33193958/change-nullable-property-of-column-in-spark-dataframe
     * and https://stackoverflow.com/questions/32585670/what-is-the-best-way-to-define-custom-methods-on-a-dataframe
@@ -853,7 +835,7 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll with TestUtils
 
 }
 
-class OpaqueSinglePartitionSuite extends OpaqueOperatorTests {
+class OpaqueOperatorSinglePartitionSuite extends OpaqueOperatorTests {
   override val spark = SparkSession.builder()
     .master("local[1]")
     .appName("QEDSuite")
@@ -863,7 +845,7 @@ class OpaqueSinglePartitionSuite extends OpaqueOperatorTests {
   override def numPartitions: Int = 1
 }
 
-class OpaqueMultiplePartitionSuite extends OpaqueOperatorTests {
+class OpaqueOperatorMultiplePartitionSuite extends OpaqueOperatorTests {
   override val spark = SparkSession.builder()
     .master("local[1]")
     .appName("QEDSuite")

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -885,7 +885,7 @@ trait OpaqueOperatorTests extends FunSuite with BeforeAndAfterAll { self =>
   }
 
   testAgainstSpark("TPC-H 9") { securityLevel =>
-    TPCH.tpch9(spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
+    TPCH.tpch(9, spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
   }
 
   testAgainstSpark("big data 1") { securityLevel =>

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -834,7 +834,7 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
 class OpaqueOperatorSinglePartitionSuite extends OpaqueOperatorTests {
   override val spark = SparkSession.builder()
     .master("local[1]")
-    .appName("QEDSuite")
+    .appName("OpaqueOperatorSinglePartitionSuite")
     .config("spark.sql.shuffle.partitions", 1)
     .getOrCreate()
 
@@ -844,7 +844,7 @@ class OpaqueOperatorSinglePartitionSuite extends OpaqueOperatorTests {
 class OpaqueOperatorMultiplePartitionSuite extends OpaqueOperatorTests {
   override val spark = SparkSession.builder()
     .master("local[1]")
-    .appName("QEDSuite")
+    .appName("OpaqueOperatorMultiplePartitionSuite")
     .config("spark.sql.shuffle.partitions", 3)
     .getOrCreate()
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -39,7 +39,7 @@ import edu.berkeley.cs.rise.opaque.expressions.DotProduct.dot
 import edu.berkeley.cs.rise.opaque.expressions.VectorMultiply.vectormultiply
 import edu.berkeley.cs.rise.opaque.expressions.VectorSum
 
-trait OpaqueOperatorTests extends TestUtils { self =>
+trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
 
     protected object testImplicits extends SQLImplicits {
       protected override def _sqlContext: SQLContext = self.spark.sqlContext

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -808,12 +808,6 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
     PageRank.run(spark, securityLevel, "256", numPartitions).collect.toSet
   }
 
-  /*
-  testAgainstSpark("TPC-H 9") { securityLevel =>
-    TPCH.tpch(9, spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
-  }
-  */
-
   testAgainstSpark("big data 1") { securityLevel =>
     BigDataBenchmark.q1(spark, securityLevel, "tiny", numPartitions).collect
   }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueTestsBase.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueTestsBase.scala
@@ -26,9 +26,10 @@ import org.apache.spark.sql.SparkSession
 import org.scalactic.TolerantNumerics
 import org.scalactic.Equality
 import org.scalatest.FunSuite
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Tag
 
 import edu.berkeley.cs.rise.opaque.benchmark._
-import org.scalatest.BeforeAndAfterAll
 
 trait OpaqueTestsBase extends FunSuite with BeforeAndAfterAll { self =>
 
@@ -62,8 +63,9 @@ trait OpaqueTestsBase extends FunSuite with BeforeAndAfterAll { self =>
     }
   }
 
-  def testAgainstSpark[A : Equality](name: String)(f: SecurityLevel => A): Unit = {
-    test(name + " - encrypted") {
+  def testAgainstSpark[A : Equality](name: String, testFunc: (String, Tag*) => ((=> Any) => Unit) = test)
+      (f: SecurityLevel => A): Unit = {
+    testFunc(name + " - encrypted") {
       // The === operator uses implicitly[Equality[A]], which compares Double and Array[Double]
       // using the numeric tolerance specified above
       assert(f(Encrypted) === f(Insecure))

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueTestsBase.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueTestsBase.scala
@@ -30,7 +30,7 @@ import org.scalatest.FunSuite
 import edu.berkeley.cs.rise.opaque.benchmark._
 import org.scalatest.BeforeAndAfterAll
 
-trait TestUtils extends FunSuite with BeforeAndAfterAll { self =>
+trait OpaqueTestsBase extends FunSuite with BeforeAndAfterAll { self =>
 
   def spark: SparkSession
   def numPartitions: Int

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -26,7 +26,7 @@ import edu.berkeley.cs.rise.opaque.benchmark.TPCH
 trait TPCHTests extends OpaqueTestsBase { self => 
 
   def size = "sf_small"
-  def tpch: TPCH
+  def tpch = new TPCH(spark.sqlContext, size)
 
   override def beforeAll(): Unit = {
     super.beforeAll();
@@ -34,11 +34,11 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   }
 
   testAgainstSpark("TPC-H 6") { securityLevel =>
-    tpch.query(6, securityLevel, spark.sqlContext).collect.toSet
+    tpch.query(6, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
   testAgainstSpark("TPC-H 9") { securityLevel =>
-    tpch.query(9, securityLevel, spark.sqlContext).collect.toSet
+    tpch.query(9, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 }
 
@@ -46,20 +46,16 @@ class TPCHSinglePartitionSuite extends TPCHTests {
   override def numPartitions: Int = 1
   override val spark = SparkSession.builder()
     .master("local[1]")
-    .appName("QEDSuite")
+    .appName("TPCHSinglePartitionSuite")
     .config("spark.sql.shuffle.partitions", numPartitions)
     .getOrCreate()
-
-  override def tpch = new TPCH(spark.sqlContext, size, numPartitions)
 }
 
 class TPCHMultiplePartitionSuite extends TPCHTests {
   override def numPartitions: Int = 3
   override val spark = SparkSession.builder()
     .master("local[1]")
-    .appName("QEDSuite")
+    .appName("TPCHMultiplePartitionSuite")
     .config("spark.sql.shuffle.partitions", numPartitions)
     .getOrCreate()
-
-  override def tpch = new TPCH(spark.sqlContext, size, numPartitions)
 }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.rise.opaque
+
+
+import org.apache.spark.sql.SparkSession
+
+import edu.berkeley.cs.rise.opaque.benchmark._
+
+trait TPCHTests extends TestUtils { self => 
+
+  testAgainstSpark("TPC-H 9") { securityLevel =>
+    TPCH.tpch(9, spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
+  }
+
+  class TCPHSinglePartitionSuite extends OpaqueOperatorTests {
+  override val spark = SparkSession.builder()
+    .master("local[1]")
+    .appName("QEDSuite")
+    .config("spark.sql.shuffle.partitions", 1)
+    .getOrCreate()
+
+  override def numPartitions: Int = 1
+  }
+
+  class OpaqueOperatorMultiplePartitionSuite extends OpaqueOperatorTests {
+  override val spark = SparkSession.builder()
+    .master("local[1]")
+    .appName("QEDSuite")
+    .config("spark.sql.shuffle.partitions", 3)
+    .getOrCreate()
+
+  override def numPartitions: Int = 3
+  }
+}

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -28,12 +28,92 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   def size = "sf_small"
   def tpch = TPCH(spark.sqlContext, size)
 
+  testAgainstSpark("TPC-H 1") { securityLevel =>
+    tpch.query(1, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 2") { securityLevel =>
+    tpch.query(2, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 3") { securityLevel =>
+    tpch.query(3, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 4") { securityLevel =>
+    tpch.query(4, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 5") { securityLevel =>
+    tpch.query(5, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
   testAgainstSpark("TPC-H 6") { securityLevel =>
     tpch.query(6, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
+  testAgainstSpark("TPC-H 7") { securityLevel =>
+    tpch.query(7, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 8") { securityLevel =>
+    tpch.query(8, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
   testAgainstSpark("TPC-H 9") { securityLevel =>
     tpch.query(9, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 10") { securityLevel =>
+    tpch.query(10, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 11") { securityLevel =>
+    tpch.query(11, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 12") { securityLevel =>
+    tpch.query(12, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 13") { securityLevel =>
+    tpch.query(13, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 14") { securityLevel =>
+    tpch.query(14, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 15") { securityLevel =>
+    tpch.query(15, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 16") { securityLevel =>
+    tpch.query(16, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 17") { securityLevel =>
+    tpch.query(17, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 18") { securityLevel =>
+    tpch.query(18, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 19") { securityLevel =>
+    tpch.query(19, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 20") { securityLevel =>
+    tpch.query(20, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 21") { securityLevel =>
+    tpch.query(21, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+  }
+
+  testAgainstSpark("TPC-H 22") { securityLevel =>
+    tpch.query(22, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 }
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -25,20 +25,11 @@ import edu.berkeley.cs.rise.opaque.benchmark.TPCH
 
 trait TPCHTests extends OpaqueTestsBase { self => 
 
+  def size = "sf_small"
   def tpch: TPCH
 
-  def size = "sf_small"
-
-  override def beforeAll(): Unit = {
-    super.beforeAll()
-  }
-
-  override def afterAll(): Unit = {
-    super.beforeAll()
-  }
-
   testAgainstSpark("TPC-H 9") { securityLevel =>
-    tpch.tpch(9, spark.sqlContext, securityLevel, size, numPartitions).collect.toSet
+    tpch.query(9, securityLevel, spark.sqlContext).collect.toSet
   }
 }
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -28,6 +28,11 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   def size = "sf_small"
   def tpch: TPCH
 
+  override def beforeAll(): Unit = {
+    super.beforeAll();
+    tpch.ensureCached();
+  }
+
   testAgainstSpark("TPC-H 6") { securityLevel =>
     tpch.query(6, securityLevel, spark.sqlContext).collect.toSet
   }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -32,7 +32,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
     tpch.query(1, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 2") { securityLevel =>
+  testAgainstSpark("TPC-H 2", ignore) { securityLevel =>
     tpch.query(2, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
@@ -40,7 +40,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
     tpch.query(3, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 4") { securityLevel =>
+  testAgainstSpark("TPC-H 4", ignore) { securityLevel =>
     tpch.query(4, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
@@ -68,15 +68,15 @@ trait TPCHTests extends OpaqueTestsBase { self =>
     tpch.query(10, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 11") { securityLevel =>
+  testAgainstSpark("TPC-H 11", ignore) { securityLevel =>
     tpch.query(11, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 12") { securityLevel =>
+  testAgainstSpark("TPC-H 12", ignore) { securityLevel =>
     tpch.query(12, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 13") { securityLevel =>
+  testAgainstSpark("TPC-H 13", ignore) { securityLevel =>
     tpch.query(13, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
@@ -84,11 +84,11 @@ trait TPCHTests extends OpaqueTestsBase { self =>
     tpch.query(14, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 15") { securityLevel =>
+  testAgainstSpark("TPC-H 15", ignore) { securityLevel =>
     tpch.query(15, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 16") { securityLevel =>
+  testAgainstSpark("TPC-H 16", ignore) { securityLevel =>
     tpch.query(16, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
@@ -100,19 +100,19 @@ trait TPCHTests extends OpaqueTestsBase { self =>
     tpch.query(18, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 19") { securityLevel =>
+  testAgainstSpark("TPC-H 19", ignore) { securityLevel =>
     tpch.query(19, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 20") { securityLevel =>
+  testAgainstSpark("TPC-H 20", ignore) { securityLevel =>
     tpch.query(20, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 21") { securityLevel =>
+  testAgainstSpark("TPC-H 21", ignore) { securityLevel =>
     tpch.query(21, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 22") { securityLevel =>
+  testAgainstSpark("TPC-H 22", ignore) { securityLevel =>
     tpch.query(22, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.SparkSession
 
 import edu.berkeley.cs.rise.opaque.benchmark._
 
-trait TPCHTests extends TestUtils { self => 
+trait TPCHTests extends OpaqueTestsBase { self => 
 
   testAgainstSpark("TPC-H 9") { securityLevel =>
     TPCH.tpch(9, spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -31,6 +31,10 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   testAgainstSpark("TPC-H 9") { securityLevel =>
     tpch.query(9, securityLevel, spark.sqlContext).collect.toSet
   }
+
+  testAgainstSpark("TPC-H 11") { securityLevel =>
+    tpch.query(11, securityLevel, spark.sqlContext).collect.toSet
+  }
 }
 
 class TPCHSinglePartitionSuite extends TPCHTests {

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -26,12 +26,7 @@ import edu.berkeley.cs.rise.opaque.benchmark.TPCH
 trait TPCHTests extends OpaqueTestsBase { self => 
 
   def size = "sf_small"
-  def tpch = new TPCH(spark.sqlContext, size)
-
-  override def beforeAll(): Unit = {
-    super.beforeAll();
-    tpch.ensureCached();
-  }
+  def tpch = TPCH(spark.sqlContext, size)
 
   testAgainstSpark("TPC-H 6") { securityLevel =>
     tpch.query(6, securityLevel, spark.sqlContext, numPartitions).collect.toSet

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -38,24 +38,24 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   testAgainstSpark("TPC-H 9") { securityLevel =>
     TPCH.tpch(9, spark.sqlContext, securityLevel, size, numPartitions).collect.toSet
   }
+}
 
-  class TPCHSinglePartitionSuite extends TPCHTests {
-  override val spark = SparkSession.builder()
-    .master("local[1]")
-    .appName("QEDSuite")
-    .config("spark.sql.shuffle.partitions", 1)
-    .getOrCreate()
+class TPCHSinglePartitionSuite extends TPCHTests {
+override val spark = SparkSession.builder()
+  .master("local[1]")
+  .appName("QEDSuite")
+  .config("spark.sql.shuffle.partitions", 1)
+  .getOrCreate()
 
-  override def numPartitions: Int = 1
-  }
+override def numPartitions: Int = 1
+}
 
-  class TPCHMultiplePartitionSuite extends TPCHTests {
-  override val spark = SparkSession.builder()
-    .master("local[1]")
-    .appName("QEDSuite")
-    .config("spark.sql.shuffle.partitions", 3)
-    .getOrCreate()
+class TPCHMultiplePartitionSuite extends TPCHTests {
+override val spark = SparkSession.builder()
+  .master("local[1]")
+  .appName("QEDSuite")
+  .config("spark.sql.shuffle.partitions", 3)
+  .getOrCreate()
 
-  override def numPartitions: Int = 3
-  }
+override def numPartitions: Int = 3
 }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -96,7 +96,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
     tpch.query(17, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 18") { securityLevel =>
+  testAgainstSpark("TPC-H 18", ignore) { securityLevel =>
     tpch.query(18, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -28,12 +28,12 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   def size = "sf_small"
   def tpch: TPCH
 
-  testAgainstSpark("TPC-H 9") { securityLevel =>
-    tpch.query(9, securityLevel, spark.sqlContext).collect.toSet
+  testAgainstSpark("TPC-H 6") { securityLevel =>
+    tpch.query(6, securityLevel, spark.sqlContext).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 11") { securityLevel =>
-    tpch.query(11, securityLevel, spark.sqlContext).collect.toSet
+  testAgainstSpark("TPC-H 9") { securityLevel =>
+    tpch.query(9, securityLevel, spark.sqlContext).collect.toSet
   }
 }
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -24,11 +24,22 @@ import edu.berkeley.cs.rise.opaque.benchmark._
 
 trait TPCHTests extends OpaqueTestsBase { self => 
 
-  testAgainstSpark("TPC-H 9") { securityLevel =>
-    TPCH.tpch(9, spark.sqlContext, securityLevel, "sf_small", numPartitions).collect.toSet
+  def size = "sf_small"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    TPCH.loadTables(spark.sqlContext, size, numPartitions);
   }
 
-  class TCPHSinglePartitionSuite extends OpaqueOperatorTests {
+  override def afterAll(): Unit = {
+    super.beforeAll()
+  }
+
+  testAgainstSpark("TPC-H 9") { securityLevel =>
+    TPCH.tpch(9, spark.sqlContext, securityLevel, size, numPartitions).collect.toSet
+  }
+
+  class TPCHSinglePartitionSuite extends TPCHTests {
   override val spark = SparkSession.builder()
     .master("local[1]")
     .appName("QEDSuite")
@@ -38,7 +49,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   override def numPartitions: Int = 1
   }
 
-  class OpaqueOperatorMultiplePartitionSuite extends OpaqueOperatorTests {
+  class TPCHMultiplePartitionSuite extends TPCHTests {
   override val spark = SparkSession.builder()
     .master("local[1]")
     .appName("QEDSuite")

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TestUtils.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TestUtils.scala
@@ -22,12 +22,30 @@ import scala.collection.mutable
 
 import org.apache.log4j.Level
 import org.apache.log4j.LogManager
+import org.apache.spark.sql.SparkSession
+import org.scalactic.TolerantNumerics
 import org.scalactic.Equality
 import org.scalatest.FunSuite
 
 import edu.berkeley.cs.rise.opaque.benchmark._
+import org.scalatest.BeforeAndAfterAll
 
-trait TestUtils extends FunSuite {
+trait TestUtils extends FunSuite with BeforeAndAfterAll { self =>
+
+  def spark: SparkSession
+  def numPartitions: Int
+
+  override def beforeAll(): Unit = {
+    Utils.initSQLContext(spark.sqlContext)
+  }
+
+  override def afterAll(): Unit = {
+    spark.stop()
+  }
+
+  // Modify the behavior of === for Double and Array[Double] to use a numeric tolerance
+  implicit val tolerantDoubleEquality = TolerantNumerics.tolerantDoubleEquality(1e-6)
+
   def equalityToArrayEquality[A : Equality](): Equality[Array[A]] = {
     new Equality[Array[A]] {
       def areEqual(a: Array[A], b: Any): Boolean = {

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TestUtils.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TestUtils.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.rise.opaque
+
+
+import scala.collection.mutable
+
+import org.apache.log4j.Level
+import org.apache.log4j.LogManager
+import org.scalactic.Equality
+import org.scalatest.FunSuite
+
+import edu.berkeley.cs.rise.opaque.benchmark._
+
+trait TestUtils extends FunSuite {
+  def equalityToArrayEquality[A : Equality](): Equality[Array[A]] = {
+    new Equality[Array[A]] {
+      def areEqual(a: Array[A], b: Any): Boolean = {
+        b match {
+          case b: Array[_] =>
+            (a.length == b.length
+              && a.zip(b).forall {
+                case (x, y) => implicitly[Equality[A]].areEqual(x, y)
+              })
+          case _ => false
+        }
+      }
+      override def toString: String = s"TolerantArrayEquality"
+    }
+  }
+
+  def testAgainstSpark[A : Equality](name: String)(f: SecurityLevel => A): Unit = {
+    test(name + " - encrypted") {
+      // The === operator uses implicitly[Equality[A]], which compares Double and Array[Double]
+      // using the numeric tolerance specified above
+      assert(f(Encrypted) === f(Insecure))
+    }
+  }
+
+  def testOpaqueOnly(name: String)(f: SecurityLevel => Unit): Unit = {
+    test(name + " - encrypted") {
+      f(Encrypted)
+    }
+  }
+
+  def testSparkOnly(name: String)(f: SecurityLevel => Unit): Unit = {
+    test(name + " - Spark") {
+      f(Insecure)
+    }
+  }
+
+  def withLoggingOff[A](f: () => A): A = {
+    val sparkLoggers = Seq(
+      "org.apache.spark",
+      "org.apache.spark.executor.Executor",
+      "org.apache.spark.scheduler.TaskSetManager")
+    val logLevels = new mutable.HashMap[String, Level]
+    for (l <- sparkLoggers) {
+      logLevels(l) = LogManager.getLogger(l).getLevel
+      LogManager.getLogger(l).setLevel(Level.OFF)
+    }
+    try {
+      f()
+    } finally {
+      for (l <- sparkLoggers) {
+        LogManager.getLogger(l).setLevel(logLevels(l))
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR refactors the single existing TPC-H query to perform operations using standard SQL rather than directly with DataFrames. This was done to expedite the process of increasing TPC-H coverage, since all of the queries are already available in SQL. It also creates a new folder to hold all queries from https://github.com/apache/spark/tree/master/sql/core/src/test/resources/tpch