### PR TITLE
Update Breeze Version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ sparkVersion := "3.0.0"
 
 sparkComponents ++= Seq("core", "sql", "catalyst")
 
-libraryDependencies += "org.scalanlp" %% "breeze" % "0.13.2"
+libraryDependencies += "org.scalanlp" %% "breeze" % "1.1"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 


### PR DESCRIPTION
This PR updates the version of Breeze in `build.sbt` to be compatible with Spark 3.0.1, which is recommended for installation in README.md