### PR TITLE
Removed calls to toSet in TPC-H tests

### DIFF
--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -49,7 +49,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   }
 
   testAgainstSpark("TPC-H 6") { securityLevel =>
-    tpch.query(6, securityLevel, spark.sqlContext, numPartitions).collect
+    tpch.query(6, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
   testAgainstSpark("TPC-H 7") { securityLevel =>
@@ -81,7 +81,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   }
 
   testAgainstSpark("TPC-H 14") { securityLevel =>
-    tpch.query(14, securityLevel, spark.sqlContext, numPartitions).collect
+    tpch.query(14, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
   testAgainstSpark("TPC-H 15", ignore) { securityLevel =>
@@ -93,7 +93,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   }
 
   testAgainstSpark("TPC-H 17") { securityLevel =>
-    tpch.query(17, securityLevel, spark.sqlContext, numPartitions).collect
+    tpch.query(17, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
   testAgainstSpark("TPC-H 18", ignore) { securityLevel =>
@@ -101,7 +101,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   }
 
   testAgainstSpark("TPC-H 19", ignore) { securityLevel =>
-    tpch.query(19, securityLevel, spark.sqlContext, numPartitions).collect
+    tpch.query(19, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
   testAgainstSpark("TPC-H 20", ignore) { securityLevel =>

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -29,91 +29,91 @@ trait TPCHTests extends OpaqueTestsBase { self =>
   def tpch = TPCH(spark.sqlContext, size)
 
   testAgainstSpark("TPC-H 1") { securityLevel =>
-    tpch.query(1, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(1, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 2", ignore) { securityLevel =>
-    tpch.query(2, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(2, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 3") { securityLevel =>
-    tpch.query(3, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(3, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 4", ignore) { securityLevel =>
-    tpch.query(4, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(4, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 5") { securityLevel =>
-    tpch.query(5, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(5, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 6") { securityLevel =>
-    tpch.query(6, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(6, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 7") { securityLevel =>
-    tpch.query(7, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(7, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 8") { securityLevel =>
-    tpch.query(8, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(8, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 9") { securityLevel =>
-    tpch.query(9, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(9, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 10") { securityLevel =>
-    tpch.query(10, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(10, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 11", ignore) { securityLevel =>
-    tpch.query(11, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(11, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 12", ignore) { securityLevel =>
-    tpch.query(12, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(12, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 13", ignore) { securityLevel =>
-    tpch.query(13, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(13, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 14") { securityLevel =>
-    tpch.query(14, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(14, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 15", ignore) { securityLevel =>
-    tpch.query(15, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(15, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 16", ignore) { securityLevel =>
-    tpch.query(16, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(16, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 17") { securityLevel =>
-    tpch.query(17, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(17, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 18", ignore) { securityLevel =>
-    tpch.query(18, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(18, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 19", ignore) { securityLevel =>
-    tpch.query(19, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(19, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 20", ignore) { securityLevel =>
-    tpch.query(20, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(20, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 21", ignore) { securityLevel =>
-    tpch.query(21, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(21, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
   testAgainstSpark("TPC-H 22", ignore) { securityLevel =>
-    tpch.query(22, securityLevel, spark.sqlContext, numPartitions).collect.toSet
+    tpch.query(22, securityLevel, spark.sqlContext, numPartitions).collect
   }
 }
 


### PR DESCRIPTION
Using `toSet` prevented queries dependent on ordering (such as ORDER BY) from being tested by that ordering.