### PR TITLE
Semijoin support

### DIFF
--- a/src/enclave/Enclave/ExpressionEvaluation.h
+++ b/src/enclave/Enclave/ExpressionEvaluation.h
@@ -1583,6 +1583,7 @@ public:
     }
 
     const tuix::JoinExpr* join_expr = flatbuffers::GetRoot<tuix::JoinExpr>(buf);
+    join_type = join_expr->join_type();
 
     if (join_expr->left_keys()->size() != join_expr->right_keys()->size()) {
       throw std::runtime_error("Mismatched join key lengths");
@@ -1639,8 +1640,13 @@ public:
     return true;
   }
 
+  tuix::JoinType get_join_type() {
+    return join_type;
+  }
+
 private:
   flatbuffers::FlatBufferBuilder builder;
+  tuix::JoinType join_type;
   std::vector<std::unique_ptr<FlatbuffersExpressionEvaluator>> left_key_evaluators;
   std::vector<std::unique_ptr<FlatbuffersExpressionEvaluator>> right_key_evaluators;
 };

--- a/src/enclave/Enclave/Join.cpp
+++ b/src/enclave/Enclave/Join.cpp
@@ -104,7 +104,6 @@ void non_oblivious_sort_merge_join(
             case tuix::JoinType_LeftSemi:
               if (leftsemi_add_row) {
                 w.append(primary, current);
-                leftsemi_add_row = false;
               }
               break;
               
@@ -115,6 +114,8 @@ void non_oblivious_sort_merge_join(
               break;
           }
         }
+
+        leftsemi_add_row = false;
       }
     }
   }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -316,6 +316,15 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
     p.join(f, $"join_col_1" === $"join_col_2").collect.toSet
   }
 
+  testAgainstSpark("left semi join") { securityLevel =>
+    val p_data = for (i <- 1 to 16) yield (i, i.toString, i * 10)
+    val f_data = for (i <- 1 to 32) yield (i, (i % 8).toString, i * 10)
+    val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
+    val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
+    val df = p.join(f, $"join_col_1" === $"join_col_2", "left_semi").sort($"join_col_1")
+    df.collect
+  }
+
   def abc(i: Int): String = (i % 3) match {
     case 0 => "A"
     case 1 => "B"

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -317,11 +317,11 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
   }
 
   testAgainstSpark("left semi join") { securityLevel =>
-    val p_data = for (i <- 1 to 16) yield (i, i.toString, i * 10)
+    val p_data = for (i <- 1 to 16) yield (i, (i % 8).toString, i * 10)
     val f_data = for (i <- 1 to 32) yield (i, (i % 8).toString, i * 10)
     val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
     val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
-    val df = p.join(f, $"join_col_1" === $"join_col_2", "left_semi").sort($"join_col_1")
+    val df = p.join(f, $"join_col_1" === $"join_col_2", "left_semi").sort($"join_col_1", $"id")
     df.collect
   }
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -40,7 +40,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
     tpch.query(3, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 4", ignore) { securityLevel =>
+  testAgainstSpark("TPC-H 4") { securityLevel =>
     tpch.query(4, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 


### PR DESCRIPTION
Add support for LeftSemi join; also handles SQL's `EXISTS` subquery. This allows Opaque to correctly run TPC-H 4.