### PR TITLE
TPC-H 20 Fix

### DIFF
--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -406,7 +406,7 @@ object Utils extends Logging {
         tuix.Field.createField(
           builder,
           tuix.FieldUnion.FloatField,
-          tuix.FloatField.createFloatField(builder, x.toString().toFloat),
+          tuix.FloatField.createFloatField(builder, x.toFloat),
           isNull)
       case (null, DecimalType()) =>
         tuix.Field.createField(

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -109,7 +109,6 @@ import edu.berkeley.cs.rise.opaque.expressions.VectorMultiply
 import edu.berkeley.cs.rise.opaque.expressions.VectorSum
 import edu.berkeley.cs.rise.opaque.logical.ConvertToOpaqueOperators
 import edu.berkeley.cs.rise.opaque.logical.EncryptLocalRelation
-import org.apache.spark.sql.catalyst.expressions.PromotePrecision
 
 object Utils extends Logging {
   private val perf: Boolean = System.getenv("SGX_PERF") == "1"
@@ -351,7 +350,7 @@ object Utils extends Logging {
     rdd.foreach(x => {})
   }
 
-  def castValue(value: Any, dataType: DataType): (Any, DataType) = {
+  def castToSupportedValue(value: Any, dataType: DataType): (Any, DataType) = {
     var newVal = value
     var newDataType = dataType
     dataType match {
@@ -366,7 +365,7 @@ object Utils extends Logging {
 
   def flatbuffersCreateField(
       builder: FlatBufferBuilder, value: Any, dataType: DataType, isNull: Boolean): Int = {
-    (castValue(value, dataType)) match {
+    (castToSupportedValue(value, dataType)) match {
       case (b: Boolean, BooleanType) =>
         tuix.Field.createField(
           builder,
@@ -409,7 +408,7 @@ object Utils extends Logging {
           tuix.FieldUnion.FloatField,
           tuix.FloatField.createFloatField(builder, x),
           isNull)
-      case (null, FloatType) =>
+      case (null, FloatType) | (null, DecimalType()) =>
         tuix.Field.createField(
           builder,
           tuix.FieldUnion.FloatField,

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -798,7 +798,7 @@ object Utils extends Logging {
         case FloatType => tuix.ColType.FloatType
         case DoubleType => tuix.ColType.DoubleType
         case StringType => tuix.ColType.StringType
-        case DecimalType() => tuix.ColType.StringType
+        case DecimalType() => tuix.ColType.FloatType
     }
   }
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -104,7 +104,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
     tpch.query(19, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 20", ignore) { securityLevel =>
+  testAgainstSpark("TPC-H 20") { securityLevel =>
     tpch.query(20, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 


### PR DESCRIPTION
This PR fixes the matching errors encountered by the TPC-H 20 test by having decimals be treated as floats in Utils.scala. This has to be done because decimals are not supported yet by the current Flatbuffer serialization.