### PR TITLE
Join update

### DIFF
--- a/src/enclave/App/App.cpp
+++ b/src/enclave/App/App.cpp
@@ -519,7 +519,7 @@ JNIEXPORT jbyteArray JNICALL Java_edu_berkeley_cs_rise_opaque_execution_SGXEncla
 }
 
 JNIEXPORT jbyteArray JNICALL
-Java_edu_berkeley_cs_rise_opaque_execution_SGXEnclave_ScanCollectLastPrimary(
+Java_edu_berkeley_cs_rise_opaque_execution_SGXEnclave_NonObliviousSortMergeJoin(
   JNIEnv *env, jobject obj, jlong eid, jbyteArray join_expr, jbyteArray input_rows) {
   (void)obj;
 
@@ -535,47 +535,6 @@ Java_edu_berkeley_cs_rise_opaque_execution_SGXEnclave_ScanCollectLastPrimary(
   size_t output_rows_length = 0;
 
   if (input_rows_ptr == nullptr) {
-    ocall_throw("ScanCollectLastPrimary: JNI failed to get input byte array.");
-  } else {
-    oe_check_and_time("Scan Collect Last Primary",
-                       ecall_scan_collect_last_primary(
-                         (oe_enclave_t*)eid,
-                         join_expr_ptr, join_expr_length,
-                         input_rows_ptr, input_rows_length,
-                         &output_rows, &output_rows_length));
-  }
-
-  jbyteArray ret = env->NewByteArray(output_rows_length);
-  env->SetByteArrayRegion(ret, 0, output_rows_length, (jbyte *) output_rows);
-  free(output_rows);
-
-  env->ReleaseByteArrayElements(join_expr, (jbyte *) join_expr_ptr, 0);
-  env->ReleaseByteArrayElements(input_rows, (jbyte *) input_rows_ptr, 0);
-
-  return ret;
-}
-
-JNIEXPORT jbyteArray JNICALL
-Java_edu_berkeley_cs_rise_opaque_execution_SGXEnclave_NonObliviousSortMergeJoin(
-  JNIEnv *env, jobject obj, jlong eid, jbyteArray join_expr, jbyteArray input_rows,
-  jbyteArray join_row) {
-  (void)obj;
-
-  jboolean if_copy;
-
-  uint32_t join_expr_length = (uint32_t) env->GetArrayLength(join_expr);
-  uint8_t *join_expr_ptr = (uint8_t *) env->GetByteArrayElements(join_expr, &if_copy);
-
-  uint32_t input_rows_length = (uint32_t) env->GetArrayLength(input_rows);
-  uint8_t *input_rows_ptr = (uint8_t *) env->GetByteArrayElements(input_rows, &if_copy);
-
-  uint32_t join_row_length = (uint32_t) env->GetArrayLength(join_row);
-  uint8_t *join_row_ptr = (uint8_t *) env->GetByteArrayElements(join_row, &if_copy);
-
-  uint8_t *output_rows = nullptr;
-  size_t output_rows_length = 0;
-
-  if (input_rows_ptr == nullptr) {
     ocall_throw("NonObliviousSortMergeJoin: JNI failed to get input byte array.");
   } else {
     oe_check_and_time("Non-Oblivious Sort-Merge Join",
@@ -583,7 +542,6 @@ Java_edu_berkeley_cs_rise_opaque_execution_SGXEnclave_NonObliviousSortMergeJoin(
                          (oe_enclave_t*)eid,
                          join_expr_ptr, join_expr_length,
                          input_rows_ptr, input_rows_length,
-                         join_row_ptr, join_row_length,
                          &output_rows, &output_rows_length));
   }
   
@@ -593,7 +551,6 @@ Java_edu_berkeley_cs_rise_opaque_execution_SGXEnclave_NonObliviousSortMergeJoin(
 
   env->ReleaseByteArrayElements(join_expr, (jbyte *) join_expr_ptr, 0);
   env->ReleaseByteArrayElements(input_rows, (jbyte *) input_rows_ptr, 0);
-  env->ReleaseByteArrayElements(join_row, (jbyte *) join_row_ptr, 0);
 
   return ret;
 }

--- a/src/enclave/App/SGXEnclave.h
+++ b/src/enclave/App/SGXEnclave.h
@@ -38,12 +38,8 @@ extern "C" {
     JNIEnv *, jobject, jlong, jbyteArray, jbyteArray);
 
   JNIEXPORT jbyteArray JNICALL
-  Java_edu_berkeley_cs_rise_opaque_execution_SGXEnclave_ScanCollectLastPrimary(
-    JNIEnv *, jobject, jlong, jbyteArray, jbyteArray);
-
-  JNIEXPORT jbyteArray JNICALL
   Java_edu_berkeley_cs_rise_opaque_execution_SGXEnclave_NonObliviousSortMergeJoin(
-    JNIEnv *, jobject, jlong, jbyteArray, jbyteArray, jbyteArray);
+    JNIEnv *, jobject, jlong, jbyteArray, jbyteArray);
 
   JNIEXPORT jobject JNICALL
   Java_edu_berkeley_cs_rise_opaque_execution_SGXEnclave_NonObliviousAggregate(

--- a/src/enclave/Enclave/Enclave.cpp
+++ b/src/enclave/Enclave/Enclave.cpp
@@ -145,35 +145,16 @@ void ecall_external_sort(uint8_t *sort_order, size_t sort_order_length,
   }
 }
 
-void ecall_scan_collect_last_primary(uint8_t *join_expr, size_t join_expr_length,
-                                     uint8_t *input_rows, size_t input_rows_length,
-                                     uint8_t **output_rows, size_t *output_rows_length) {
-  // Guard against operating on arbitrary enclave memory
-  assert(oe_is_outside_enclave(input_rows, input_rows_length) == 1);
-  __builtin_ia32_lfence();
-
-  try {
-    scan_collect_last_primary(join_expr, join_expr_length,
-                              input_rows, input_rows_length,
-                              output_rows, output_rows_length);
-  } catch (const std::runtime_error &e) {
-    ocall_throw(e.what());
-  }
-}
-
 void ecall_non_oblivious_sort_merge_join(uint8_t *join_expr, size_t join_expr_length,
                                          uint8_t *input_rows, size_t input_rows_length,
-                                         uint8_t *join_row, size_t join_row_length,
                                          uint8_t **output_rows, size_t *output_rows_length) {
   // Guard against operating on arbitrary enclave memory
   assert(oe_is_outside_enclave(input_rows, input_rows_length) == 1);
-  assert(oe_is_outside_enclave(join_row, join_row_length) == 1);
   __builtin_ia32_lfence();
 
   try {
     non_oblivious_sort_merge_join(join_expr, join_expr_length,
                                   input_rows, input_rows_length,
-                                  join_row, join_row_length,
                                   output_rows, output_rows_length);
   } catch (const std::runtime_error &e) {
     ocall_throw(e.what());

--- a/src/enclave/Enclave/Enclave.edl
+++ b/src/enclave/Enclave/Enclave.edl
@@ -43,15 +43,9 @@ enclave {
       [user_check] uint8_t *input_rows, size_t input_rows_length,
       [out] uint8_t **output_rows, [out] size_t *output_rows_length);
 
-    public void ecall_scan_collect_last_primary(
-      [in, count=join_expr_length] uint8_t *join_expr, size_t join_expr_length,
-      [user_check] uint8_t *input_rows, size_t input_rows_length,
-      [out] uint8_t **output_rows, [out] size_t *output_rows_length);
-
     public void ecall_non_oblivious_sort_merge_join(
       [in, count=join_expr_length] uint8_t *join_expr, size_t join_expr_length,
       [user_check] uint8_t *input_rows, size_t input_rows_length,
-      [user_check] uint8_t *join_row, size_t join_row_length,
       [out] uint8_t **output_rows, [out] size_t *output_rows_length);
 
     public void ecall_non_oblivious_aggregate(

--- a/src/enclave/Enclave/ExpressionEvaluation.h
+++ b/src/enclave/Enclave/ExpressionEvaluation.h
@@ -1583,6 +1583,7 @@ public:
     }
 
     const tuix::JoinExpr* join_expr = flatbuffers::GetRoot<tuix::JoinExpr>(buf);
+    join_type = join_expr->join_type();
 
     if (join_expr->left_keys()->size() != join_expr->right_keys()->size()) {
       throw std::runtime_error("Mismatched join key lengths");
@@ -1639,8 +1640,13 @@ public:
     return true;
   }
 
+  tuix::JoinType get_join_type() {
+    return join_type;
+  }
+
 private:
   flatbuffers::FlatBufferBuilder builder;
+  tuix::JoinType join_type;
   std::vector<std::unique_ptr<FlatbuffersExpressionEvaluator>> left_key_evaluators;
   std::vector<std::unique_ptr<FlatbuffersExpressionEvaluator>> right_key_evaluators;
 };

--- a/src/enclave/Enclave/Join.cpp
+++ b/src/enclave/Enclave/Join.cpp
@@ -64,6 +64,7 @@ void non_oblivious_sort_merge_join(
 
   while (r.has_next()) {
     const tuix::Row *current = r.next();
+    print(current);
 
     if (join_expr_eval.is_primary(current)) {
       if (last_primary_of_group.get()
@@ -110,6 +111,7 @@ void non_oblivious_sort_merge_join(
           if (join_type == tuix::JoinType_Inner) {
             w.append(primary, current);
           } else if (join_type == tuix::JoinType_LeftSemi) {
+            // Only output the pk group ONCE
             if (!pk_fk_match) {
               w.append(primary);
             }
@@ -118,12 +120,14 @@ void non_oblivious_sort_merge_join(
 
         pk_fk_match = true;
       } else {
-        pk_fk_match = false;
+        // If pk_fk_match were true, and the code got to here, then that means the group match has not been "cleared" yet
+        // It will be processed when the code advances to the next pk group
+        pk_fk_match &= true;
       }
     }
   }
 
-  if (!pk_fk_match && join_type == tuix::JoinType_LeftAnti) {
+  if (join_type == tuix::JoinType_LeftAnti && !pk_fk_match) {
     auto primary_group_buffer = primary_group.output_buffer();
     RowReader primary_group_reader(primary_group_buffer.view());
           

--- a/src/enclave/Enclave/Join.cpp
+++ b/src/enclave/Enclave/Join.cpp
@@ -5,66 +5,23 @@
 #include "FlatbuffersWriters.h"
 #include "common.h"
 
-void scan_collect_last_primary(
-  uint8_t *join_expr, size_t join_expr_length,
-  uint8_t *input_rows, size_t input_rows_length,
-  uint8_t **output_rows, size_t *output_rows_length) {
-
-  FlatbuffersJoinExprEvaluator join_expr_eval(join_expr, join_expr_length);
-  RowReader r(BufferRefView<tuix::EncryptedBlocks>(input_rows, input_rows_length));
-  RowWriter w;
-
-  FlatbuffersTemporaryRow last_primary;
-
-  // Accumulate all primary table rows from the same group as the last primary row into `w`.
-  //
-  // Because our distributed sorting algorithm uses range partitioning over the join keys, all
-  // primary rows belonging to the same group will be colocated in the same partition. (The
-  // corresponding foreign rows may be in the same partition or the next partition.) Therefore it is
-  // sufficient to send primary rows at most one partition forward.
-  while (r.has_next()) {
-    const tuix::Row *row = r.next();
-    if (join_expr_eval.is_primary(row)) {
-      if (!last_primary.get() || !join_expr_eval.is_same_group(last_primary.get(), row)) {
-        w.clear();
-        last_primary.set(row);
-      }
-
-      w.append(row);
-    } else {
-      w.clear();
-      last_primary.set(nullptr);
-    }
-  }
-
-  w.output_buffer(output_rows, output_rows_length);
-}
-
 void non_oblivious_sort_merge_join(
   uint8_t *join_expr, size_t join_expr_length,
   uint8_t *input_rows, size_t input_rows_length,
-  uint8_t *join_row, size_t join_row_length,
   uint8_t **output_rows, size_t *output_rows_length) {
 
   FlatbuffersJoinExprEvaluator join_expr_eval(join_expr, join_expr_length);
   tuix::JoinType join_type = join_expr_eval.get_join_type();
   RowReader r(BufferRefView<tuix::EncryptedBlocks>(input_rows, input_rows_length));
-  RowReader j(BufferRefView<tuix::EncryptedBlocks>(join_row, join_row_length));
   RowWriter w;
 
   RowWriter primary_group;
   FlatbuffersTemporaryRow last_primary_of_group;
-  while (j.has_next()) {
-    const tuix::Row *row = j.next();
-    primary_group.append(row);
-    last_primary_of_group.set(row);
-  }
 
   bool pk_fk_match = false;
 
   while (r.has_next()) {
     const tuix::Row *current = r.next();
-    print(current);
 
     if (join_expr_eval.is_primary(current)) {
       if (last_primary_of_group.get()

--- a/src/enclave/Enclave/Join.cpp
+++ b/src/enclave/Enclave/Join.cpp
@@ -104,7 +104,6 @@ void non_oblivious_sort_merge_join(
             case tuix::JoinType_LeftSemi:
               if (leftsemi_add_row) {
                 w.append(primary, current);
-                leftsemi_add_row = false;
               }
               break;
               
@@ -115,6 +114,8 @@ void non_oblivious_sort_merge_join(
               break;
           }
         }
+
+        leftsemi_add_row = false;
       }
     }
   }

--- a/src/enclave/Enclave/Join.h
+++ b/src/enclave/Enclave/Join.h
@@ -4,15 +4,9 @@
 #ifndef JOIN_H
 #define JOIN_H
 
-void scan_collect_last_primary(
-  uint8_t *join_expr, size_t join_expr_length,
-  uint8_t *input_rows, size_t input_rows_length,
-  uint8_t **output_rows, size_t *output_rows_length);
-
 void non_oblivious_sort_merge_join(
     uint8_t *join_expr, size_t join_expr_length,
     uint8_t *input_rows, size_t input_rows_length,
-    uint8_t *join_row, size_t join_row_length,
     uint8_t **output_rows, size_t *output_rows_length);
 
 #endif

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/execution/SGXEnclave.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/execution/SGXEnclave.scala
@@ -39,10 +39,8 @@ class SGXEnclave extends java.io.Serializable {
     boundaries: Array[Byte]): Array[Array[Byte]]
   @native def ExternalSort(eid: Long, order: Array[Byte], input: Array[Byte]): Array[Byte]
 
-  @native def ScanCollectLastPrimary(
-    eid: Long, joinExpr: Array[Byte], input: Array[Byte]): Array[Byte]
   @native def NonObliviousSortMergeJoin(
-    eid: Long, joinExpr: Array[Byte], input: Array[Byte], joinRow: Array[Byte]): Array[Byte]
+    eid: Long, joinExpr: Array[Byte], input: Array[Byte]): Array[Byte]
 
   @native def NonObliviousAggregate(
     eid: Long, aggOp: Array[Byte], inputRows: Array[Byte], isPartial: Boolean): (Array[Byte])

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/execution/operators.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/execution/operators.scala
@@ -26,7 +26,10 @@ import org.apache.spark.sql.catalyst.expressions.AttributeSet
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.JoinType
+import org.apache.spark.sql.catalyst.plans.LeftAnti
+import org.apache.spark.sql.catalyst.plans.LeftSemi
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.SparkPlan
 
@@ -274,9 +277,15 @@ case class EncryptedSortMergeJoinExec(
     rightKeys: Seq[Expression],
     leftSchema: Seq[Attribute],
     rightSchema: Seq[Attribute],
-    output: Seq[Attribute],
     child: SparkPlan)
-  extends UnaryExecNode with OpaqueOperatorExec {
+    extends UnaryExecNode with OpaqueOperatorExec {
+
+  override def output: Seq[Attribute] = {
+    joinType match {
+      case Inner => (leftSchema ++ rightSchema).map(_.toAttribute)
+      case LeftSemi | LeftAnti => leftSchema.map(_.toAttribute)
+    }
+  }
 
   override def executeBlocked(): RDD[Block] = {
     val joinExprSer = Utils.serializeJoinExpression(
@@ -285,15 +294,6 @@ case class EncryptedSortMergeJoinExec(
     timeOperator(
       child.asInstanceOf[OpaqueOperatorExec].executeBlocked(),
       "EncryptedSortMergeJoinExec") { childRDD =>
-
-      // val lastPrimaryRows = childRDD.map { block =>
-      //   val (enclave, eid) = Utils.initEnclave()
-      //   Block(enclave.ScanCollectLastPrimary(eid, joinExprSer, block.bytes))
-      // }.collect
-      // val shifted = Utils.emptyBlock +: lastPrimaryRows.dropRight(1)
-      // assert(shifted.size == childRDD.partitions.length)
-      // val processedJoinRowsRDD =
-      //   sparkContext.parallelize(shifted, childRDD.partitions.length)
 
       childRDD.map { block =>
         val (enclave, eid) = Utils.initEnclave()

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
@@ -91,7 +91,6 @@ object OpaqueOperators extends Strategy {
         rightKeysProj,
         leftProjSchema.map(_.toAttribute),
         rightProjSchema.map(_.toAttribute),
-        (leftProjSchema ++ rightProjSchema).map(_.toAttribute),
         sorted)
 
       val tagsDropped = joinType match {

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -325,6 +325,15 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
     df.collect
   }
 
+  testAgainstSpark("left anti join") { securityLevel =>
+    val p_data = for (i <- 1 to 16) yield (i, (i % 9).toString, i * 10)
+    val f_data = for (i <- 1 to 32) yield (i, ((i % 7) + 1).toString, i * 10)
+    val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
+    val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
+    val df = p.join(f, $"join_col_1" === $"join_col_2", "left_anti").sort($"join_col_1", $"id")
+    df.collect
+  }
+
   def abc(i: Int): String = (i % 3) match {
     case 0 => "A"
     case 1 => "B"

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -325,9 +325,18 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
     df.collect
   }
 
-  testAgainstSpark("left anti join") { securityLevel =>
-    val p_data = for (i <- 1 to 16) yield (i, (i % 9).toString, i * 10)
-    val f_data = for (i <- 1 to 32) yield (i, ((i % 7) + 1).toString, i * 10)
+  testAgainstSpark("left anti join 1") { securityLevel =>
+    val p_data = for (i <- 1 to 128) yield (i, (i % 16).toString, i * 10)
+    val f_data = for (i <- 1 to 256 if (i % 3) + 1 == 0 || (i % 3) + 5 == 0) yield (i, i.toString, i * 10)
+    val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
+    val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
+    val df = p.join(f, $"join_col_1" === $"join_col_2", "left_anti").sort($"join_col_1", $"id")
+    df.collect
+  }
+
+  testAgainstSpark("left anti join 2") { securityLevel =>
+    val p_data = for (i <- 1 to 16) yield (i, (i % 4).toString, i * 10)
+    val f_data = for (i <- 1 to 32) yield (i, i.toString, i * 10)
     val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
     val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
     val df = p.join(f, $"join_col_1" === $"join_col_2", "left_anti").sort($"join_col_1", $"id")

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -316,6 +316,15 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
     p.join(f, $"join_col_1" === $"join_col_2").collect.toSet
   }
 
+  testAgainstSpark("left semi join") { securityLevel =>
+    val p_data = for (i <- 1 to 16) yield (i, i.toString, i * 10)
+    val f_data = for (i <- 1 to 32) yield (i, (i % 8).toString, i * 10)
+    val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
+    val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
+    val df = p.join(f, $"join_col_1" === $"join_col_2", "left_semi").sort($"join_col_1")
+    df.collect
+  }
+
   def abc(i: Int): String = (i % 3) match {
     case 0 => "A"
     case 1 => "B"

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -305,7 +305,7 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
     val f_data = for (i <- 1 to 256 - 16) yield ((i % 16).toString, (i * 10).toString, i.toFloat)
     val p = makeDF(p_data, securityLevel, "pk", "x")
     val f = makeDF(f_data, securityLevel, "fk", "x", "y")
-    p.join(f, $"pk" === $"fk").collect.toSet
+    val df = p.join(f, $"pk" === $"fk").collect.toSet
   }
 
   testAgainstSpark("non-foreign-key join") { securityLevel =>
@@ -319,9 +319,9 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
   testAgainstSpark("left semi join") { securityLevel =>
     val p_data = for (i <- 1 to 16) yield (i, (i % 8).toString, i * 10)
     val f_data = for (i <- 1 to 32) yield (i, (i % 8).toString, i * 10)
-    val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
-    val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
-    val df = p.join(f, $"join_col_1" === $"join_col_2", "left_semi").sort($"join_col_1", $"id")
+    val p = makeDF(p_data, securityLevel, "id1", "join_col_1", "x")
+    val f = makeDF(f_data, securityLevel, "id2", "join_col_2", "x")
+    val df = p.join(f, $"join_col_1" === $"join_col_2", "left_semi").sort($"join_col_1", $"id1")
     df.collect
   }
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -317,11 +317,11 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
   }
 
   testAgainstSpark("left semi join") { securityLevel =>
-    val p_data = for (i <- 1 to 16) yield (i, i.toString, i * 10)
+    val p_data = for (i <- 1 to 16) yield (i, (i % 8).toString, i * 10)
     val f_data = for (i <- 1 to 32) yield (i, (i % 8).toString, i * 10)
     val p = makeDF(p_data, securityLevel, "id", "join_col_1", "x")
     val f = makeDF(f_data, securityLevel, "id", "join_col_2", "x")
-    val df = p.join(f, $"join_col_1" === $"join_col_2", "left_semi").sort($"join_col_1")
+    val df = p.join(f, $"join_col_1" === $"join_col_2", "left_semi").sort($"join_col_1", $"id")
     df.collect
   }
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -40,7 +40,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
     tpch.query(3, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 
-  testAgainstSpark("TPC-H 4", ignore) { securityLevel =>
+  testAgainstSpark("TPC-H 4") { securityLevel =>
     tpch.query(4, securityLevel, spark.sqlContext, numPartitions).collect.toSet
   }
 


### PR DESCRIPTION
This PR has two contributions:
1. Adds support for two more join types: left semijoin and left antijoin. Currently also fixes TPC-H query 4.
2. Changes the implementation of join to no longer require passing the last primary group to from the previous partition to the next partition. This is done by splitting the sort operation into two separate operations: partition and sort. The new join operator partitions and sorts on different columns, thus eliminating the limitation specified in this [comment](https://github.com/mc2-project/opaque/blob/0d69b7be0cfc8df129392278cb9d4da4f69f1124/src/enclave/Enclave/Join.cpp#L21).