### PR TITLE
Float expressions

### DIFF
--- a/src/enclave/Enclave/ExpressionEvaluation.h
+++ b/src/enclave/Enclave/ExpressionEvaluation.h
@@ -1573,18 +1573,18 @@ private:
 
     case tuix::ExprUnion_NormalizeNaNAndZero:
     {
-      auto *expr = static_cast<const tuix::NormalizeNaNAndZero>(expr->expr());
-      auto child_offset = eval_helper(row, expr->child());
+      auto normalize = static_cast<const tuix::NormalizeNaNAndZero *>(expr->expr());
+      auto child_offset = eval_helper(row, normalize->child());
 
       const tuix::Field *value = flatbuffers::GetTemporaryPointer(builder, child_offset);
 
       if (value->value_type() != tuix::FieldUnion_FloatField && value->value_type() != tuix::FieldUnion_DoubleField) {
         throw std::runtime_error(
           std::string("tuix::NormalizeNaNAndZero requires type Float or Double, not ")
-          + std::string(tuix::EnumNameFieldUnion(str->value_type())));
+          + std::string(tuix::EnumNameFieldUnion(value->value_type())));
       }
 
-      bool result_is_null = str->is_null();
+      bool result_is_null = value->is_null();
 
       if (value->value_type() != tuix::FieldUnion_FloatField) {
         if (!result_is_null) {

--- a/src/enclave/Enclave/ExpressionEvaluation.h
+++ b/src/enclave/Enclave/ExpressionEvaluation.h
@@ -1586,9 +1586,9 @@ private:
 
       bool result_is_null = value->is_null();
 
-      if (value->value_type() != tuix::FieldUnion_FloatField) {
+      if (value->value_type() == tuix::FieldUnion_FloatField) {
         if (!result_is_null) {
-          float v = value->value();
+          float v = value->value_as_FloatField()->value();
           if (isnan(v)) {
             v = std::numeric_limits<float>::quiet_NaN();
           } else if (v == -0.0f) {
@@ -1611,7 +1611,7 @@ private:
       } else {
 
         if (!result_is_null) {
-          double v = value->value();
+          double v = value->value_as_DoubleField()->value();
           if (isnan(v)) {
             v = std::numeric_limits<double>::quiet_NaN();
           } else if (v == -0.0d) {
@@ -1630,7 +1630,6 @@ private:
           tuix::FieldUnion_DoubleField,
           tuix::CreateDoubleField(builder, 0).Union(),
           result_is_null);
-        
       }
     }
 

--- a/src/flatbuffers/Expr.fbs
+++ b/src/flatbuffers/Expr.fbs
@@ -36,12 +36,12 @@ union ExprUnion {
     VectorMultiply,
     DotProduct,
     Exp,
+    NormalizeNaNAndZero,
     ClosestPoint,
     CreateArray,
     Upper,
     DateAdd,
-    DateAddInterval,
-    NormalizeNaNAndZero
+    DateAddInterval
 }
 
 table Expr {
@@ -199,6 +199,10 @@ table CreateArray {
     children:[Expr];
 }
 
+table NormalizeNaNAndZero {
+    child:Expr;
+}
+
 // Opaque UDFs
 table VectorAdd {
     left:Expr;
@@ -221,9 +225,5 @@ table ClosestPoint {
 }
 
 table Upper {
-    child:Expr;
-}
-
-table NormalizeNaNAndZero {
     child:Expr;
 }

--- a/src/flatbuffers/Expr.fbs
+++ b/src/flatbuffers/Expr.fbs
@@ -40,7 +40,8 @@ union ExprUnion {
     CreateArray,
     Upper,
     DateAdd,
-    DateAddInterval
+    DateAddInterval,
+    NormalizeNaNAndZero
 }
 
 table Expr {
@@ -220,5 +221,9 @@ table ClosestPoint {
 }
 
 table Upper {
+    child:Expr;
+}
+
+table NormalizeNaNAndZero {
     child:Expr;
 }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -59,6 +59,7 @@ import org.apache.spark.sql.catalyst.expressions.If
 import org.apache.spark.sql.catalyst.expressions.In
 import org.apache.spark.sql.catalyst.expressions.IsNotNull
 import org.apache.spark.sql.catalyst.expressions.IsNull
+import org.apache.spark.sql.catalyst.expressions.KnownFloatingPointNormalized
 import org.apache.spark.sql.catalyst.expressions.LessThan
 import org.apache.spark.sql.catalyst.expressions.LessThanOrEqual
 import org.apache.spark.sql.catalyst.expressions.Literal
@@ -89,6 +90,7 @@ import org.apache.spark.sql.catalyst.plans.NaturalJoin
 import org.apache.spark.sql.catalyst.plans.RightOuter
 import org.apache.spark.sql.catalyst.plans.UsingJoin
 import org.apache.spark.sql.catalyst.trees.TreeNode
+import org.apache.spark.sql.catalyst.optimizer.NormalizeNaNAndZero
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.catalyst.util.MapData
@@ -1111,6 +1113,12 @@ object Utils extends Logging {
         case (CheckOverflow(child, dataType, _), Seq(childOffset)) =>
           // TODO: Implement decimal serialization, followed by CheckOverflow
           childOffset
+
+        case (KnownFloatingPointNormalized(NormalizeNaNAndZero(child)), Seq(childOffset)) =>
+          tuix.Expr.createExpr(
+            builder,
+            tuix.ExprUnion.NormalizeNaNAndZero,
+            tuix.NormalizeNaNAndZero.createNormalizeNaNAndZero(builder, childOffset))
 
         case (_, Seq(childOffset)) =>
           throw new OpaqueException("Expression not supported: " + expr.toString())

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -1210,7 +1210,6 @@ object Utils extends Logging {
             )
           }
 
-
         case (_, Seq(childOffset)) =>
           throw new OpaqueException("Expression not supported: " + expr.toString())
       }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -1114,11 +1114,14 @@ object Utils extends Logging {
           // TODO: Implement decimal serialization, followed by CheckOverflow
           childOffset
 
-        case (KnownFloatingPointNormalized(NormalizeNaNAndZero(child)), Seq(childOffset)) =>
+        case (NormalizeNaNAndZero(child), Seq(childOffset)) =>
           tuix.Expr.createExpr(
             builder,
             tuix.ExprUnion.NormalizeNaNAndZero,
             tuix.NormalizeNaNAndZero.createNormalizeNaNAndZero(builder, childOffset))
+
+        case (KnownFloatingPointNormalized(NormalizeNaNAndZero(child)), Seq(childOffset)) =>
+          flatbuffersSerializeExpression(builder, NormalizeNaNAndZero(child), input)
 
         case (_, Seq(childOffset)) =>
           throw new OpaqueException("Expression not supported: " + expr.toString())

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCHBenchmark.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/benchmark/TPCHBenchmark.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.SQLContext
 object TPCHBenchmark {
 
   // Add query numbers here once they are supported
-  val supportedQueries = Seq(1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 17, 19, 20, 22)
+  val supportedQueries = Seq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 17, 19, 20, 22)
 
   def query(queryNumber: Int, tpch: TPCH, sqlContext: SQLContext, numPartitions: Int) = {
     val sqlStr = tpch.getQuery(queryNumber)

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -345,8 +345,29 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
   }
 
   testAgainstSpark("join on floats") { securityLevel =>
-    val p_data = for (i <- 1 to 16) yield (i, i.toFloat, i * 10)
-    val f_data = for (i <- 1 to 256 - 16) yield (i, i.toFloat, i * 10)
+    val p_data = for (i <- 0 to 16) yield (i, i.toFloat, i * 10)
+    val f_data = (0 until 256).map(x => {
+      if (x % 3 == 0)
+        (x, null.asInstanceOf[Float], x * 10)
+      else
+        (x, (x % 16).asInstanceOf[Float], x * 10)
+    }).toSeq
+
+    val p = makeDF(p_data, securityLevel, "id", "pk", "x")
+    val f = makeDF(f_data, securityLevel, "id", "fk", "x")
+    val df = p.join(f, $"pk" === $"fk")
+    df.collect.toSet
+  }
+
+  testAgainstSpark("join on doubles") { securityLevel =>
+    val p_data = for (i <- 0 to 16) yield (i, i.toDouble, i * 10)
+    val f_data = (0 until 256).map(x => {
+      if (x % 3 == 0)
+        (x, null.asInstanceOf[Double], x * 10)
+      else
+        (x, (x % 16).asInstanceOf[Double], x * 10)
+    }).toSeq
+
     val p = makeDF(p_data, securityLevel, "id", "pk", "x")
     val f = makeDF(f_data, securityLevel, "id", "fk", "x")
     val df = p.join(f, $"pk" === $"fk")

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -343,6 +343,14 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
     df.collect
   }
 
+  testAgainstSpark("join on floats") { securityLevel =>
+    val p_data = for (i <- 1 to 16) yield (i, i.toFloat, i * 10)
+    val f_data = for (i <- 1 to 256 - 16) yield (i, i.toFloat, i * 10)
+    val p = makeDF(p_data, securityLevel, "id", "pk", "x")
+    val f = makeDF(f_data, securityLevel, "id", "fk", "x")
+    p.join(f, $"pk" === $"fk").collect.toSet
+  }
+
   def abc(i: Int): String = (i % 3) match {
     case 0 => "A"
     case 1 => "B"

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -348,7 +348,8 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
     val f_data = for (i <- 1 to 256 - 16) yield (i, i.toFloat, i * 10)
     val p = makeDF(p_data, securityLevel, "id", "pk", "x")
     val f = makeDF(f_data, securityLevel, "id", "fk", "x")
-    p.join(f, $"pk" === $"fk").collect.toSet
+    val df = p.join(f, $"pk" === $"fk")
+    df.collect.toSet
   }
 
   def abc(i: Int): String = (i % 3) match {

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/TPCHTests.scala
@@ -32,7 +32,7 @@ trait TPCHTests extends OpaqueTestsBase { self =>
     tpch.query(1, securityLevel, spark.sqlContext, numPartitions).collect
   }
 
-  testAgainstSpark("TPC-H 2", ignore) { securityLevel =>
+  testAgainstSpark("TPC-H 2") { securityLevel =>
     tpch.query(2, securityLevel, spark.sqlContext, numPartitions).collect
   }
 


### PR DESCRIPTION
This PR adds float normalization expressions [implemented in Spark](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingNumbers.scala#L170). TPC-H query 2 also passes.