### PR TITLE
Support for distinct aggregations

### DIFF
--- a/src/enclave/Enclave/Aggregate.cpp
+++ b/src/enclave/Enclave/Aggregate.cpp
@@ -30,8 +30,8 @@ void non_oblivious_aggregate(
     count += 1;
   }
 
-  // Skip outputting the final row if the number of input rows is 0 AND
-  // 1. It's a grouping aggregation, OR
+  // Skip outputting the final row if:
+  // 1. The number of input rows is 0 AND it's a grouping aggregation, OR
   // 2. It's a global aggregation, the mode is final
   if (!(count == 0 && (agg_op_eval.get_num_grouping_keys() > 0 || (agg_op_eval.get_num_grouping_keys() == 0 && !is_partial)))) {
     w.append(agg_op_eval.evaluate());

--- a/src/enclave/Enclave/ExpressionEvaluation.h
+++ b/src/enclave/Enclave/ExpressionEvaluation.h
@@ -1811,6 +1811,9 @@ public:
         std::unique_ptr<FlatbuffersExpressionEvaluator>(
           new FlatbuffersExpressionEvaluator(eval_expr)));
     }
+    is_distinct = expr->is_distinct();
+    value_selector = std::unique_ptr<FlatbuffersExpressionEvaluator>(
+        new FlatbuffersExpressionEvaluator(expr->value_selector()));
   }
 
   std::vector<const tuix::Field *> initial_values(const tuix::Row *unused) {
@@ -1824,6 +1827,15 @@ public:
   std::vector<const tuix::Field *> update(const tuix::Row *concat) {
     std::vector<const tuix::Field *> result;
     for (auto&& e : update_evaluators) {
+      if (is_distinct) {
+        std::string value = to_string(value_selector->eval(concat));
+        /* Check to see if this distinct value has already been counted */
+        if (observed_values.count(value)) { 
+          std::vector<const tuix::Field *> vect(1, nullptr);
+          return vect;
+        }
+        observed_values.insert(value);
+      }
       result.push_back(e->eval(concat));
     }
     return result;
@@ -1837,11 +1849,18 @@ public:
     return result;
   }
 
+  void clear_observed_values() {
+    observed_values.clear();
+  }
+
 private:
   flatbuffers::FlatBufferBuilder builder;
   std::vector<std::unique_ptr<FlatbuffersExpressionEvaluator>> initial_value_evaluators;
   std::vector<std::unique_ptr<FlatbuffersExpressionEvaluator>> update_evaluators;
   std::vector<std::unique_ptr<FlatbuffersExpressionEvaluator>> evaluate_evaluators;
+  bool is_distinct;
+  std::unique_ptr<FlatbuffersExpressionEvaluator> value_selector;
+  std::set<std::string> observed_values;
 };
 
 class FlatbuffersAggOpEvaluator {
@@ -1880,6 +1899,7 @@ public:
     // Write initial values to a
     std::vector<flatbuffers::Offset<tuix::Field>> init_fields;
     for (auto&& e : aggregate_evaluators) {
+      e->clear_observed_values();
       for (auto f : e->initial_values(nullptr)) {
         init_fields.push_back(flatbuffers_copy<tuix::Field>(f, builder2));
       }
@@ -1901,6 +1921,7 @@ public:
   void aggregate(const tuix::Row *row) {
     builder.Clear();
     flatbuffers::Offset<tuix::Row> concat;
+    int a_length = a->field_values()->size();
 
     std::vector<flatbuffers::Offset<tuix::Field>> concat_fields;
     // concat row to a
@@ -1918,9 +1939,18 @@ public:
     std::vector<flatbuffers::Offset<tuix::Field>> output_fields;
     for (auto&& e : aggregate_evaluators) {
       for (auto f : e->update(concat_ptr)) {
+        if (f == nullptr) { // Only triggered on EXPR(distinct expr ...)
+          output_fields.clear();
+          for (int i = 0; i < a_length; i++) {
+            auto f = concat_ptr->field_values()->Get(i);
+            output_fields.push_back(flatbuffers_copy<tuix::Field>(f, builder2));
+          }
+          goto save_a;
+        } 
         output_fields.push_back(flatbuffers_copy<tuix::Field>(f, builder2));
       }
     }
+save_a:
     a = flatbuffers::GetTemporaryPointer<tuix::Row>(
       builder2, tuix::CreateRowDirect(builder2, &output_fields));
   }

--- a/src/flatbuffers/operators.fbs
+++ b/src/flatbuffers/operators.fbs
@@ -38,6 +38,9 @@ table AggregateExpr {
     initial_values: [Expr];
     update_exprs: [Expr];
     evaluate_exprs: [Expr];
+    // Items below are used for EXPR(distinct col_name ...)
+    is_distinct: bool;
+    value_selector: Expr;
 }
 // Supported: Average, Count, First, Last, Max, Min, Sum
 

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
@@ -109,25 +109,47 @@ object OpaqueOperators extends Strategy {
         if (isEncrypted(child) && aggExpressions.forall(expr => expr.isInstanceOf[AggregateExpression])) =>
 
       val aggregateExpressions = aggExpressions.map(expr => expr.asInstanceOf[AggregateExpression])
+      val (functionsWithDistinct, functionsWithoutDistinct) = aggregateExpressions.partition(_.isDistinct)
 
-      if (groupingExpressions.size == 0) {
-        // Global aggregation
-        val partialAggregate = EncryptedAggregateExec(groupingExpressions, aggregateExpressions, Partial, planLater(child))
-        val partialOutput = partialAggregate.output
-        val (projSchema, tag) = tagForGlobalAggregate(partialOutput)
+      functionsWithDistinct.size match {
+        case size if size == 0 => // No distinct aggregate operations
+          if (groupingExpressions.size == 0) {
+            // Global aggregation
+            val partialAggregate = EncryptedAggregateExec(groupingExpressions, aggregateExpressions, Partial, planLater(child))
+            val partialOutput = partialAggregate.output
+            val (projSchema, tag) = tagForGlobalAggregate(partialOutput)
 
-        EncryptedProjectExec(resultExpressions, 
-          EncryptedAggregateExec(groupingExpressions, aggregateExpressions, Final, 
-            EncryptedProjectExec(partialOutput, 
-              EncryptedSortExec(Seq(SortOrder(tag, Ascending)), true, 
-                EncryptedProjectExec(projSchema, partialAggregate))))) :: Nil
-      } else {
-        // Grouping aggregation
-        EncryptedProjectExec(resultExpressions,
-          EncryptedAggregateExec(groupingExpressions, aggregateExpressions, Final,
-            EncryptedSortExec(groupingExpressions.map(_.toAttribute).map(e => SortOrder(e, Ascending)), true,
-              EncryptedAggregateExec(groupingExpressions, aggregateExpressions, Partial,
-                EncryptedSortExec(groupingExpressions.map(e => SortOrder(e, Ascending)), false, planLater(child)))))) :: Nil
+            EncryptedProjectExec(resultExpressions, 
+              EncryptedAggregateExec(groupingExpressions, aggregateExpressions, Final, 
+                EncryptedProjectExec(partialOutput,
+                  EncryptedSortExec(Seq(SortOrder(tag, Ascending)), true, 
+                    EncryptedProjectExec(projSchema, partialAggregate))))) :: Nil
+          } else {
+            // Grouping aggregation
+            EncryptedProjectExec(resultExpressions,
+              EncryptedAggregateExec(groupingExpressions, aggregateExpressions, Final,
+                EncryptedSortExec(groupingExpressions.map(_.toAttribute).map(e => SortOrder(e, Ascending)), true,
+                  EncryptedAggregateExec(groupingExpressions, aggregateExpressions, Partial,
+                    EncryptedSortExec(groupingExpressions.map(e => SortOrder(e, Ascending)), false, planLater(child)))))) :: Nil
+          }
+        case size if size == 1 => // One distinct aggregate operation
+          if (groupingExpressions.size == 0) {
+            // Global aggregation
+            val partialAggregate = EncryptedAggregateExec(groupingExpressions, aggregateExpressions, Partial, planLater(child))
+            val partialOutput = partialAggregate.output
+            val (projSchema, tag) = tagForGlobalAggregate(partialOutput)
+
+            EncryptedProjectExec(resultExpressions, 
+              EncryptedAggregateExec(groupingExpressions, aggregateExpressions, Final, 
+                  EncryptedProjectExec(partialOutput,
+                    EncryptedSortExec(Seq(SortOrder(tag, Ascending)), true,
+                      EncryptedProjectExec(projSchema, partialAggregate))))) :: Nil
+          } else {
+            // Grouping aggregation
+            EncryptedProjectExec(resultExpressions,
+              EncryptedAggregateExec(groupingExpressions, aggregateExpressions, Complete,
+                EncryptedSortExec(groupingExpressions.map(e => SortOrder(e, Ascending)), true, planLater(child)))) :: Nil
+          }
       }
 
     case p @ Union(Seq(left, right)) if isEncrypted(p) =>

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -377,6 +377,13 @@ trait OpaqueOperatorTests extends OpaqueTestsBase { self =>
       .collect.sortBy { case Row(category: String, _) => category }
   }
 
+  testAgainstSpark("aggregate count - distinct") { securityLevel =>
+    val data = (0 until 32).map{ i => (abc(i), i % 8)}.toSeq
+    val words = makeDF(data, securityLevel, "category", "price")
+    words.groupBy("category").agg(countDistinct("price").as("distinctPrices"))
+      .collect.sortBy { case Row(category: String, _) => category }
+  }
+
   testAgainstSpark("aggregate first") { securityLevel =>
     val data = for (i <- 0 until 256) yield (i, abc(i), 1)
     val words = makeDF(data, securityLevel, "id", "category", "price")


### PR DESCRIPTION
This is part 2 of making TPC-H 16 work.

Currently, our aggregation code does not support aggregate expressions that have `isDistinct` set to true. This PR intends to add support for that by doing two things:

1. Serializing an `is_distinct` field for aggregate expressions and implementing a set-based tracker in C++ that updates rows according to the aggregate expression if `is_distinct` is false or if the given value was not already seen.
2. In Scala, checking if an aggregate operation has any aggregate expressions with `isDistinct = true`. If this is the case, then we need to perform a global sort before the partial aggregation. This is to make sure that the same aggregate values are not distributed across different partitions and are not counted more than once.