### PR TITLE
Multiple Partition tests run with local-cluster instead of local

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -12,12 +12,26 @@ sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-
 # Install Opaque Dependencies
 sudo apt -y install wget build-essential openjdk-8-jdk python libssl-dev
 
+# Install a newer version of CMake (>= 3.13)
 wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh
 sudo bash cmake-3.15.6-Linux-x86_64.sh --skip-license --prefix=/usr/local
+
+# Install Spark 3.1.1
+wget https://downloads.apache.org/spark/spark-3.1.1/spark-3.1.1-bin-hadoop2.7.tgz
+tar xvf spark-3.1.1*
+sudo mkdir /opt/spark
+sudo mv spark-3.1.1*/* /opt/spark
+rm -rf spark-3.1.1*
+sudo chmod -R +wx /opt/spark/work
+
+# Set Spark environment variables
+export SPARK_HOME=/opt/spark
+export PATH=$PATH:/opt/spark/bin:/opt/spark/sbin
 
 # Generate keypair for attestation
 openssl genrsa -out ./private_key.pem -3 3072
 
+# Set Opaque environment variables
 source opaqueenv
 source /opt/openenclave/share/openenclave/openenclaverc
 export MODE=SIMULATE

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -12,7 +12,7 @@ sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-
 # Install Opaque Dependencies
 sudo apt -y install wget build-essential openjdk-8-jdk python libssl-dev
 
-# Install a newer version of CMake (>= 3.13)
+# Install a newer version of CMake (3.15)
 wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh
 sudo bash cmake-3.15.6-Linux-x86_64.sh --skip-license --prefix=/usr/local
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,31 @@ UDFs must be [implemented in C++](#user-defined-functions-udfs).
 
 ## Installation
 
-After downloading the Opaque codebase, build and test it as follows.
+After downloading the Opaque codebase, build and test it on Ubuntu 18.04 as follows.
 
 1. Install dependencies and the [OpenEnclave SDK](https://github.com/openenclave/openenclave/blob/v0.12.0/docs/GettingStartedDocs/install_oe_sdk-Ubuntu_18.04.md). We currently support OE version 0.12.0 (so please install with `open-enclave=0.12.0`) and Ubuntu 18.04.
 
     ```sh
-    # For Ubuntu 18.04:
     sudo apt install wget build-essential openjdk-8-jdk python libssl-dev
     
     # Install a newer version of CMake (>= 3.13)
     wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh
     sudo bash cmake-3.15.6-Linux-x86_64.sh --skip-license --prefix=/usr/local
+
+    # Install Spark 3.1.1 (if not already done)
+    wget https://downloads.apache.org/spark/spark-3.1.1/spark-3.1.1-bin-hadoop2.7.tgz
+    tar xvf spark-3.1.1*
+    sudo mkdir /opt/spark
+    sudo mv spark-3.1.1*/* /opt/spark
+    rm -rf spark-3.1.1*
+    sudo chmod -R +wx /opt/spark/work # may not be needed, depends on where Spark is installed
+
+    # Set Spark environment variables in .bashrc
+    echo "" >> ~/.bashrc
+    echo "# Spark settings" >> ~/.bashrc
+    echo "export SPARK_HOME=/opt/spark" >> ~/.bashrc
+    echo "export PATH=$PATH:/opt/spark/bin:/opt/spark/sbin" >> ~/.bashrc
+    source ~/.bashrc
     ```
 
 2. On the master, generate a keypair using OpenSSL for remote attestation.
@@ -60,7 +74,7 @@ After downloading the Opaque codebase, build and test it as follows.
 
 ## Usage
 
-Next, run Apache Spark SQL queries with Opaque as follows, assuming [Spark 3.0.1](https://www.apache.org/dyn/closer.lua/spark/spark-3.0.1/spark-3.0.1-bin-hadoop2.7.tgz) (`wget http://apache.mirrors.pair.com/spark/spark-3.0.1/spark-3.0.1-bin-hadoop2.7.tgz`) is already installed:
+Next, run Apache Spark SQL queries with Opaque as follows:
 
 \* Opaque needs Spark's `'spark.executor.instances'` property to be set. This can be done in a custom config file, the default config file found at `/opt/spark/conf/spark-defaults.conf`, or as a `spark-submit` or `spark-shell` argument: `--conf 'spark.executor.instances=<value>`.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ After downloading the Opaque codebase, build and test it on Ubuntu 18.04 as foll
     ```sh
     sudo apt install wget build-essential openjdk-8-jdk python libssl-dev
     
-    # Install a newer version of CMake (>= 3.13)
+    # Install a newer version of CMake (3.15)
     wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh
     sudo bash cmake-3.15.6-Linux-x86_64.sh --skip-license --prefix=/usr/local
 

--- a/build.sbt
+++ b/build.sbt
@@ -136,8 +136,9 @@ val synthTestDataTask = TaskKey[Unit]("synthTestData", "Synthesizes test data.")
 /*
  * local-cluster[*,*,*] in our tests requires a packaged .jar file to run correctly.
  * See https://stackoverflow.com/questions/28186607/java-lang-classcastexception-using-lambda-expressions-in-spark-job-on-remote-ser
- * The following code creates dependencies for test and testOnly to ensure that the given .jar is always created by
- * build/sbt package before running any tests. Note that .class files are still only compiled ONCE for both package and tests.
+ * The following code creates dependencies for test and testOnly to ensure that the required .jar is always created by
+ * build/sbt package before running any tests. Note that .class files are still only compiled ONCE for both package and tests,
+ * so the performance impact is very minimal.
  */
 test in Test := {
   (synthTestDataTask).value

--- a/data/tpch/synth-tpch-data
+++ b/data/tpch/synth-tpch-data
@@ -9,6 +9,6 @@ git clone https://github.com/electrum/tpch-dbgen
 cd tpch-dbgen
 make -j$(nproc)
 ./dbgen -vf -s 0.01
-mkdir -p $SPARKSGX_DATA_DIR/tpch/sf_small
+mkdir -p $OPAQUE_DATA_DIR/tpch/sf_small
 chmod u+r *.tbl
-cp *.tbl $SPARKSGX_DATA_DIR/tpch/sf_small/
+cp *.tbl $OPAQUE_DATA_DIR/tpch/sf_small/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN openssl ecparam -name prime256v1 -genkey -noout -out private_key.pem
 RUN git clone https://github.com/ucbrise/opaque.git
 WORKDIR /home/opaque/opaque
 
-ENV SPARKSGX_DATA_DIR="/home/opaque/opaque/data"
+ENV OPAQUE_DATA_DIR="/home/opaque/opaque/data"
 ENV PRIVATE_KEY_PATH="/home/opaque/private_key.pem"
 
 RUN build/sbt test:compile

--- a/opaqueenv
+++ b/opaqueenv
@@ -1,5 +1,6 @@
 export OPAQUE_HOME=$(pwd)
 export SPARKSGX_DATA_DIR=${OPAQUE_HOME}/data/
+export SPARK_SCALA_VERSION=2.12
 export PRIVATE_KEY_PATH=${OPAQUE_HOME}/private_key.pem
 export MODE=HARDWARE
 export OE_SDK_PATH=/opt/openenclave/

--- a/opaqueenv
+++ b/opaqueenv
@@ -1,5 +1,5 @@
 export OPAQUE_HOME=$(pwd)
-export SPARKSGX_DATA_DIR=${OPAQUE_HOME}/data/
+export OPAQUE_DATA_DIR=${OPAQUE_HOME}/data/
 export SPARK_SCALA_VERSION=2.12
 export PRIVATE_KEY_PATH=${OPAQUE_HOME}/private_key.pem
 export MODE=HARDWARE

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.6")
 
 addSbtPlugin("ch.jodersky" % "sbt-jni" % "1.2.6")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueOperatorTests.scala
@@ -1315,14 +1315,17 @@ class OpaqueOperatorSinglePartitionSuite extends OpaqueOperatorTests {
 }
 
 class OpaqueOperatorMultiplePartitionSuite extends OpaqueOperatorTests {
+  val executorInstances = 3
+
+  override def numPartitions = executorInstances
   override val spark = SparkSession
     .builder()
-    .master("local[1]")
+    .master(s"local-cluster[$executorInstances,1,1024]")
     .appName("OpaqueOperatorMultiplePartitionSuite")
-    .config("spark.sql.shuffle.partitions", 3)
+    .config("spark.executor.instances", executorInstances)
+    .config("spark.sql.shuffle.partitions", numPartitions)
+    .config("spark.jars", "target/scala-2.12/opaque_2.12-0.1.jar")
     .getOrCreate()
-
-  override def numPartitions: Int = 3
 
   import testImplicits._
 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueTolerance.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueTolerance.scala
@@ -9,14 +9,14 @@ trait OpaqueTolerance {
   implicit val tolerantDoubleEquality = TolerantNumerics.tolerantDoubleEquality(1e-6)
   implicit val tolerantDoubleArrayEquality = equalityToArrayEquality[Double]
 
-  def equalityToArrayEquality[A : Equality](): Equality[Array[A]] = {
+  def equalityToArrayEquality[A: Equality](): Equality[Array[A]] = {
     new Equality[Array[A]] {
       def areEqual(a: Array[A], b: Any): Boolean = {
         b match {
           case b: Array[_] =>
             (a.length == b.length
-              && a.zip(b).forall {
-                case (x, y) => implicitly[Equality[A]].areEqual(x, y)
+              && a.zip(b).forall { case (x, y) =>
+                implicitly[Equality[A]].areEqual(x, y)
               })
           case _ => false
         }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueTolerance.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueTolerance.scala
@@ -9,14 +9,14 @@ trait OpaqueTolerance {
   implicit val tolerantDoubleEquality = TolerantNumerics.tolerantDoubleEquality(1e-6)
   implicit val tolerantDoubleArrayEquality = equalityToArrayEquality[Double]
 
-  def equalityToArrayEquality[A: Equality](): Equality[Array[A]] = {
+  def equalityToArrayEquality[A : Equality](): Equality[Array[A]] = {
     new Equality[Array[A]] {
       def areEqual(a: Array[A], b: Any): Boolean = {
         b match {
           case b: Array[_] =>
             (a.length == b.length
-              && a.zip(b).forall { case (x, y) =>
-                implicitly[Equality[A]].areEqual(x, y)
+              && a.zip(b).forall {
+                case (x, y) => implicitly[Equality[A]].areEqual(x, y)
               })
           case _ => false
         }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/benchmark/Benchmark.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/benchmark/Benchmark.scala
@@ -54,10 +54,10 @@ object Benchmark {
   var fileUrl = "file://"
 
   def dataDir: String = {
-    if (System.getenv("SPARKSGX_DATA_DIR") == null) {
-      throw new Exception("Set SPARKSGX_DATA_DIR")
+    if (System.getenv("OPAQUE_DATA_DIR") == null) {
+      throw new Exception("Set OPAQUE_DATA_DIR")
     }
-    System.getenv("SPARKSGX_DATA_DIR")
+    System.getenv("OPAQUE_DATA_DIR")
   }
 
   def logisticRegression() = {

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/tpch/TPCHTests.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/tpch/TPCHTests.scala
@@ -54,13 +54,17 @@ class TPCHSinglePartitionSuite extends TPCHTests {
 }
 
 class TPCHMultiplePartitionSuite extends TPCHTests {
-  override def numPartitions: Int = 3
+  val executorInstances = 3
+
+  override def numPartitions = executorInstances
   override val spark = SparkSession
     .builder()
-    .master("local[1]")
-    .appName("TPCHMultiplePartitionSuite")
+    .master(s"local-cluster[$executorInstances,1,1024]")
+    .appName("MultiplePartitionJoinSuite")
+    .config("spark.executor.instances", executorInstances)
     .config("spark.sql.shuffle.partitions", numPartitions)
+    .config("spark.jars", "target/scala-2.12/opaque_2.12-0.1.jar")
     .getOrCreate()
 
-  runTests();
+  runTests()
 }


### PR DESCRIPTION
Resolves https://github.com/mc2-project/opaque/issues/168.

This PR includes the necessary changes in order to have our multiple partition tests use local-cluster as master instead of local. Using local-cluster enables us to test more functionality, such as remote attestation, without having to spin up a physical cluster and use a non-local file system such as HDFS. The major changes include new build dependencies for test/testOnly, as well as requiring a local installation of Spark before running `build/sbt test`.