### PR TITLE
Error handling for missing functionalities

### DIFF
--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -1283,7 +1283,7 @@ object Utils extends Logging {
           }
 
         case (_, Seq(childOffset)) =>
-          throw new OpaqueException("Expression not supported: " + expr.toString())
+          throw new OpaqueException("Expression not supported: " + expr.toString() + " in Opaque")
       }
     }
   }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -1282,7 +1282,7 @@ object Utils extends Logging {
             )
           }
 
-        case (_, Seq(childOffset)) =>
+        case _ =>
           throw new OpaqueException("Expression " + expr.toString() + " is not supported in Opaque")
       }
     }
@@ -1819,6 +1819,9 @@ object Utils extends Logging {
             evaluateExprs.map(e => flatbuffersSerializeExpression(builder, e, aggSchema)).toArray
           )
         )
+
+      case _ =>
+        throw new OpaqueException("Aggregate expression " + e.aggregateFunction.toString() + " is not supported in Opaque")
     }
   }
 

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -643,7 +643,7 @@ object Utils extends Logging {
         )
       case _ =>
         throw new OpaqueException(
-          s"FlatbuffersCreateField failed to match on ${value} of type {value.getClass.getName()}, ${dataType}"
+          s"Opaque currently does not support serializing ${value} of type {value.getClass.getName()}, ${dataType}"
         )
     }
   }
@@ -910,7 +910,7 @@ object Utils extends Logging {
       case DecimalType() => tuix.ColType.FloatType
       case DoubleType => tuix.ColType.DoubleType
       case StringType => tuix.ColType.StringType
-      case _ => throw new OpaqueException("Type not supported: " + dataType.toString())
+      case _ => throw new OpaqueException("Type currently not supported: " + dataType.toString())
     }
   }
 
@@ -1283,7 +1283,7 @@ object Utils extends Logging {
           }
 
         case _ =>
-          throw new OpaqueException("Expression " + expr.toString() + " is not supported in Opaque")
+          throw new OpaqueException("Expression " + expr.toString() + " is currently not supported in Opaque")
       }
     }
   }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -1283,7 +1283,7 @@ object Utils extends Logging {
           }
 
         case (_, Seq(childOffset)) =>
-          throw new OpaqueException("Expression not supported: " + expr.toString() + " in Opaque")
+          throw new OpaqueException("Expression " + expr.toString() + " is not supported in Opaque")
       }
     }
   }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/execution/operators.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/execution/operators.scala
@@ -224,11 +224,10 @@ case class EncryptedProjectExec(projectList: Seq[NamedExpression], child: SparkP
     extends UnaryExecNode
     with OpaqueOperatorExec {
 
-  val projectListSer = Utils.serializeProjectList(projectList, child.output)
-
   override def output: Seq[Attribute] = projectList.map(_.toAttribute)
 
   override def executeBlocked(): RDD[Block] = {
+    val projectListSer = Utils.serializeProjectList(projectList, child.output)
     timeOperator(
       child.asInstanceOf[OpaqueOperatorExec].executeBlocked(),
       "EncryptedProjectExec"
@@ -245,11 +244,10 @@ case class EncryptedFilterExec(condition: Expression, child: SparkPlan)
     extends UnaryExecNode
     with OpaqueOperatorExec {
 
-  val conditionSer = Utils.serializeFilterExpression(condition, child.output)
-
   override def output: Seq[Attribute] = child.output
 
   override def executeBlocked(): RDD[Block] = {
+    val conditionSer = Utils.serializeFilterExpression(condition, child.output)
     timeOperator(child.asInstanceOf[OpaqueOperatorExec].executeBlocked(), "EncryptedFilterExec") {
       childRDD =>
         childRDD.map { block =>
@@ -267,8 +265,6 @@ case class EncryptedAggregateExec(
 ) extends UnaryExecNode
     with OpaqueOperatorExec {
 
-  val aggExprSer = Utils.serializeAggOp(groupingExpressions, aggregateExpressions, child.output)
-
   override def producedAttributes: AttributeSet =
     AttributeSet(aggregateExpressions) -- AttributeSet(groupingExpressions)
 
@@ -283,6 +279,8 @@ case class EncryptedAggregateExec(
     })
 
   override def executeBlocked(): RDD[Block] = {
+
+    val aggExprSer = Utils.serializeAggOp(groupingExpressions, aggregateExpressions, child.output)
     val isPartial = aggregateExpressions
       .map(expr => expr.mode)
       .exists(mode => mode == Partial || mode == PartialMerge)
@@ -310,15 +308,6 @@ case class EncryptedSortMergeJoinExec(
 ) extends UnaryExecNode
     with OpaqueOperatorExec {
 
-  val joinExprSer = Utils.serializeJoinExpression(
-      joinType,
-      Some(leftKeys),
-      Some(rightKeys),
-      leftSchema,
-      rightSchema,
-      condition
-    )
-
   override def output: Seq[Attribute] = {
     joinType match {
       case Inner =>
@@ -337,6 +326,15 @@ case class EncryptedSortMergeJoinExec(
   }
 
   override def executeBlocked(): RDD[Block] = {
+    val joinExprSer = Utils.serializeJoinExpression(
+      joinType,
+      Some(leftKeys),
+      Some(rightKeys),
+      leftSchema,
+      rightSchema,
+      condition
+    )
+
     timeOperator(
       child.asInstanceOf[OpaqueOperatorExec].executeBlocked(),
       "EncryptedSortMergeJoinExec"
@@ -358,9 +356,6 @@ case class EncryptedBroadcastNestedLoopJoinExec(
 ) extends BinaryExecNode
     with OpaqueOperatorExec {
 
-  val joinExprSer =
-    Utils.serializeJoinExpression(joinType, None, None, left.output, right.output, condition)
-
   override def output: Seq[Attribute] = {
     joinType match {
       case _: InnerLike =>
@@ -379,6 +374,9 @@ case class EncryptedBroadcastNestedLoopJoinExec(
   }
 
   override def executeBlocked(): RDD[Block] = {
+    val joinExprSer =
+      Utils.serializeJoinExpression(joinType, None, None, left.output, right.output, condition)
+
     // We pick which side to broadcast/stream according to buildSide.
     // BuildRight means the right relation <=> the broadcast relation.
     // NOTE: outer_rows and inner_rows in C++ correspond to stream and broadcast side respectively.

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
@@ -355,7 +355,7 @@ object OpaqueOperators extends Strategy with JoinSelectionHelper {
 
     case _ =>
       if (isEncrypted(plan)) {
-        throw new OpaqueException(s"Logical operator ${plan.nodeName}(${plan.argString(10)}) is not supported in Opaque")
+        throw new OpaqueException(s"Logical operator ${plan.nodeName}(${plan.argString(10)}) is currently not supported in Opaque")
       }
 
       Nil

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
@@ -355,7 +355,7 @@ object OpaqueOperators extends Strategy with JoinSelectionHelper {
 
     case _ =>
       if (isEncrypted(plan)) {
-        throw new OpaqueException(s"Logical node ${plan.nodeName}(${plan.argString(10)}) is not supported in Opaque")
+        throw new OpaqueException(s"Logical operator ${plan.nodeName}(${plan.argString(10)}) is not supported in Opaque")
       }
 
       Nil

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/strategies.scala
@@ -353,7 +353,12 @@ object OpaqueOperators extends Strategy with JoinSelectionHelper {
     case EncryptedBlockRDD(output, rdd) =>
       EncryptedBlockRDDScanExec(output, rdd) :: Nil
 
-    case _ => Nil
+    case _ =>
+      if (isEncrypted(plan)) {
+        throw new OpaqueException(s"Logical node ${plan.nodeName}(${plan.argString(10)}) is not supported in Opaque")
+      }
+
+      Nil
   }
 
   private def tagForEquiJoin(


### PR DESCRIPTION
This PR introduces better error handling for missing operators and expressions. For operators, the planning stage in strategies will throw an error if there is an unmatched logical operator. For expressions, then existing code will already fail early because `executeBlocked()` will run immediately for every operator and return a lazily evaluated RDD. Therefore, the expressions will also be serialized before the RDD is eagerly evaluated.