### PR TITLE
Listener support for submitting through Spark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 
 libraryDependencies ++= Seq(
   "io.grpc" % "grpc-netty" % scalapb.compiler.Version.grpcJavaVersion,
-  "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
+  "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion,
+  "com.google.guava" % "guava" % "21.0"
 )
 
 enablePlugins(SparkPlugin)
@@ -31,6 +32,14 @@ assemblyMergeStrategy in (Test, assembly) := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x => MergeStrategy.first
 }
+
+/* Include the newer version of com.google.guava found in libraryDependencies
+ * in the fat jar rather than 14.0 supplied by Spark (gRPC does not work otherwise)
+ * TODO: support running the listener with the jar produced by build/sbt assembly.
+ */
+assemblyShadeRules in (Test, assembly) := Seq(
+  ShadeRule.rename("com.google.**" -> "my_conf.@1").inAll
+)
 
 /*
  * local-cluster[*,*,*] in our tests requires a packaged .jar file to run correctly.

--- a/docs/src/usage/functionality.rst
+++ b/docs/src/usage/functionality.rst
@@ -50,7 +50,7 @@ DataFrame interface
 Because Opaque SQL only replaces physical operators to work with encrypted data, the DataFrame interface is exactly the same as Spark's both for `Scala <https://spark.apache.org/docs/3.1.1/api/scala/org/apache/spark/sql/Dataset.html>`_ and `Python <https://spark.apache.org/docs/3.1.1/api/python/reference/api/pyspark.sql.DataFrame.html?highlight=dataframe#pyspark.sql.DataFrame>`_. Opaque SQL is still a work in progress, so not all of these functionalities are currently implemented. See below for a complete list in Scala.
 
 Supported operations
-*******************
+********************
 
 Actions
 -------

--- a/docs/src/usage/usage.rst
+++ b/docs/src/usage/usage.rst
@@ -3,20 +3,23 @@ Using Opaque SQL
 ****************
 
 Setup
-*****
-Opaque SQL needs two Spark properties to be set:
+#####
+Opaque SQL needs three Spark properties to be set:
 
 - ``spark.executor.instances``
 - ``spark.task.maxFailures``
-
-Both of these are used for remote attestation: Opaque SQL needs to know how many executors are in the cluster, and to use Spark's fault tolerance property to attest unattested executors.
+-  ``spark.driver.defaultJavaOptions="-Dscala.color"`` (if running the gRPC listener)
 
 These properties can be be set in a custom configuration file, the default being located at ``${SPARK_HOME}/conf/spark-defaults.conf``, or as a ``spark-submit`` or ``spark-shell`` argument: ``--conf <key>=<value>``.
 
 Running Opaque SQL
-******************
+##################
 
-Once setup is finished, you can run Spark SQL queries as follows.
+Once setup is finished, there are multiple ways to run Opaque depending on the intended functionality.
+
+Running the interactive shell
+*****************************
+
 
 1. Package Opaque into a JAR.
 
@@ -40,7 +43,7 @@ Once setup is finished, you can run Spark SQL queries as follows.
                    pyspark --py-files ${OPAQUE_HOME}/target/scala-2.12/opaque_2.12-0.1.jar  \
                      --jars ${OPAQUE_HOME}/target/scala-2.12/opaque_2.12-0.1.jar
     
-   (the reason we need to specify `--py-files` is because the Opaque Python functions are placed in the .jar for easier packaging)
+   (we need to specify `--py-files` is because the Opaque Python functions are placed in the .jar for easier packaging)
     
 3. Inside the Spark shell, import Opaque's DataFrame methods and install Opaque's query planner rules.
 
@@ -60,7 +63,7 @@ Once setup is finished, you can run Spark SQL queries as follows.
                    
     
 
-4. You can also run queries in Scala locally.
+4. Alternatively, you can also run queries in Scala locally.
 
    .. code-block:: bash
 
@@ -71,15 +74,26 @@ Once setup is finished, you can run Spark SQL queries as follows.
 Starting the gRPC Listener
 **************************
 
-1. To start the gRPC listener for the Opaque Client and TMS to connect to is easy.
+1. To run locally for easy testing/functionality:
 
    .. code-block:: bash
 
-                   cd ${OPAQUE_HOME}
                    build/sbt run
 
+2. To launch the listener on a standalone Spark cluster:
+
+   .. code-block:: bash
+
+                  build/sbt test:assembly # create a fat jar with all necessary dependencies
+
+                  spark-submit --class edu.berkeley.cs.rise.opaque.rpc.Listener  \
+                     <Spark configuration parameters> \
+                     --deploy-mode client ${OPAQUE_HOME}/target/scala-2.12/opaque-assembly-0.1.jar
+
+Both of these methods then allow you to use the MC2-Client to submit queries to Opaque SQL remotely!
+
 Encrypting, saving, and loading a DataFrame
-*******************************************
+###########################################
 
 1. Create an unencrypted DataFrame on the driver.
    This should be done on the client, i.e., in a trusted setting.
@@ -132,7 +146,7 @@ Encrypting, saving, and loading a DataFrame
                   df_encrypted.write.format("edu.berkeley.cs.rise.opaque.EncryptedSource").save("df_encrypted")
 
 Using the DataFrame interface
-*****************************
+#############################
 
 1. Users can load the :ref:`previously persisted encrypted DataFrame<save_df>`.
 
@@ -177,7 +191,7 @@ Call ``.collect`` or ``.show`` to retreive the results. The final result will be
 
 
 Using the SQL interface
-***********************
+#######################
 
 1. Users can also load the :ref:`previously persisted encrypted DataFrame <save_df>` using the SQL interface.
 


### PR DESCRIPTION
This PR includes the necessary changes to have the Listener class run correctly when submitted to a formal Spark cluster.

We need to provide the fat jar created by build/sbt test:assembly with a newer version of the google.guava library. This is because the gRPC library did not work with the one provided by Spark, which was 14.0. This involves adding a shading rule that changes all previous classpaths prepending by com.google to the new library included in libraryDependencies.
The Spark shell had its own custom formatting that was causing results received on the client side to include some parsing rules that were not being evaluated. There is now a line in the docs mentioning to set "-Dscala.color" on starting up the JVM, which is sbt's default.
We had to explicitly add the jars provided to Spark to the new IMain's classpath, otherwise the Spark library could not be found.
Also includes updates to docs to reflect these changes.