### PR TITLE
Fix warning for non-Spark configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -199,7 +199,7 @@ initialCommands in console :=
     |val spark = (org.apache.spark.sql.SparkSession.builder()
     |  .master("local")
     |  .appName("Opaque shell")
-    |  .config("opaque.testing.enableSharedKey", true)
+    |  .config("spark.opaque.testing.enableSharedKey", true)
     |  .getOrCreate())
     |val sc = spark.sparkContext
     |val sqlContext = spark.sqlContext

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/Utils.scala
@@ -298,7 +298,7 @@ object Utils extends Logging {
     sqlContext.experimental.extraStrategies = (Seq(OpaqueOperators) ++
       sqlContext.experimental.extraStrategies)
 
-    val enableSharedKey = sqlContext.getConf("opaque.testing.enableSharedKey", "false")
+    val enableSharedKey = sqlContext.getConf("spark.opaque.testing.enableSharedKey", "false")
     if (enableSharedKey.toBoolean) {
       sharedKey = Some(Array.fill[Byte](GCM_KEY_LENGTH)(0))
     }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/rpc/IntpHandler.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/rpc/IntpHandler.scala
@@ -78,7 +78,7 @@ object IntpHandler {
       /* Opaque SQL specific commands */
       "@transient val sqlContext = spark.sqlContext",
       // Use dummy key for attestation for now.
-      "spark.conf.set(\"opaque.testing.enableSharedKey\", \"true\")",
+      "spark.conf.set(\"spark.opaque.testing.enableSharedKey\", \"true\")",
       """
         import edu.berkeley.cs.rise.opaque.implicits._
         try { 

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/SharedSparkSessions.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/SharedSparkSessions.scala
@@ -26,7 +26,7 @@ trait SinglePartitionSparkSession {
     .master("local[*]")
     .appName("SinglePartitionSuiteSession")
     .config("spark.sql.shuffle.partitions", numPartitions)
-    .config("opaque.testing.enableSharedKey", true)
+    .config("spark.opaque.testing.enableSharedKey", true)
     .getOrCreate()
 }
 
@@ -44,6 +44,6 @@ trait MultiplePartitionSparkSession {
       "spark.jars",
       "target/scala-2.12/opaque_2.12-0.1.jar,target/scala-2.12/opaque_2.12-0.1-tests.jar"
     )
-    .config("opaque.testing.enableSharedKey", true)
+    .config("spark.opaque.testing.enableSharedKey", true)
     .getOrCreate()
 }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/benchmark/Benchmark.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/benchmark/Benchmark.scala
@@ -51,7 +51,7 @@ object Benchmark {
   val spark = SparkSession
     .builder()
     .appName("Benchmark")
-    .config("opaque.testing.enableSharedKey", true)
+    .config("spark.opaque.testing.enableSharedKey", true)
     .getOrCreate()
 
   var numPartitions = spark.sparkContext.defaultParallelism


### PR DESCRIPTION
Need to prepend `spark.` to a custom config, otherwise it gets ignored by Spark.