### PR TITLE
IntpHandler: capture stdout and return to the client

### DIFF
--- a/src/main/scala/edu/berkeley/cs/rise/opaque/rpc/IntpHandler.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/rpc/IntpHandler.scala
@@ -99,7 +99,7 @@ object IntpHandler {
       val ret = out.getBuffer.toString
       (ret, res)
     }
-    (ret + "\n\n stdout: \n\n" + captured.toString, res)
+    (captured.toString + "\n----------------------------\n" + ret, res)
   }
   def run(lines: Seq[String]): (String, Result) = run(lines.map(_ + "\n").mkString)
 }

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/rpc/IntpHandler.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/rpc/IntpHandler.scala
@@ -92,7 +92,11 @@ object IntpHandler {
   }
 
   def run(input: String): (String, Result) = this.synchronized {
+    /* Need to redirect stdout to a new output stream captured. */
     val captured = new ByteArrayOutputStream()
+    /* ret: The actual output of running Scala code.
+     * res: Result object indicating whether or not the line was interpreter successfully.
+     */
     val (ret, res) = Console.withOut(captured) {
       out.getBuffer.setLength(0)
       val res = intp.interpret(input)

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/rpc/IntpHandler.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/rpc/IntpHandler.scala
@@ -92,10 +92,14 @@ object IntpHandler {
   }
 
   def run(input: String): (String, Result) = this.synchronized {
-    out.getBuffer.setLength(0)
-    val res = intp.interpret(input)
-    val output = out.getBuffer.toString
-    (output, res)
+    val captured = new ByteArrayOutputStream()
+    val (ret, res) = Console.withOut(captured) {
+      out.getBuffer.setLength(0)
+      val res = intp.interpret(input)
+      val ret = out.getBuffer.toString
+      (ret, res)
+    }
+    (ret + "\n\n stdout: \n\n" + captured.toString, res)
   }
   def run(lines: Seq[String]): (String, Result) = run(lines.map(_ + "\n").mkString)
 }


### PR DESCRIPTION
Have the client receive both the result returned by computation as well as any print statements (or other outputs to `Console.out`)