### PR TITLE
Better assembly build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ assemblyMergeStrategy in (Test, assembly) := commonMergeStrategy
 /* Include the newer version of com.google.guava found in libraryDependencies
  * in the fat jar rather than 14.0 supplied by Spark (gRPC does not work otherwise)
  */
-lazy val commonShadeRules = Seq(ShadeRule.rename("com.google.**" -> "my_conf.@1").inAll)
+lazy val commonShadeRules = Seq(ShadeRule.rename("com.google.**" -> "updatedGuava.@1").inAll)
 assemblyShadeRules in assembly := commonShadeRules
 assemblyShadeRules in (Test, assembly) := commonShadeRules
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,20 +26,25 @@ fork in Test := true
 
 /* Create fat jar with src and test classes using build/sbt test:assembly */
 Project.inConfig(Test)(baseAssemblySettings)
+
+test in assembly := {}
 test in (Test, assembly) := {}
 
-assemblyMergeStrategy in (Test, assembly) := {
-  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
-  case x => MergeStrategy.first
-}
+lazy val commonMergeStrategy: String => sbtassembly.MergeStrategy =
+  x =>
+    x match {
+      case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+      case x => MergeStrategy.first
+    }
+assemblyMergeStrategy in assembly := commonMergeStrategy
+assemblyMergeStrategy in (Test, assembly) := commonMergeStrategy
 
 /* Include the newer version of com.google.guava found in libraryDependencies
  * in the fat jar rather than 14.0 supplied by Spark (gRPC does not work otherwise)
- * TODO: support running the listener with the jar produced by build/sbt assembly.
  */
-assemblyShadeRules in (Test, assembly) := Seq(
-  ShadeRule.rename("com.google.**" -> "my_conf.@1").inAll
-)
+lazy val commonShadeRules = Seq(ShadeRule.rename("com.google.**" -> "my_conf.@1").inAll)
+assemblyShadeRules in assembly := commonShadeRules
+assemblyShadeRules in (Test, assembly) := commonShadeRules
 
 /*
  * local-cluster[*,*,*] in our tests requires a packaged .jar file to run correctly.

--- a/docs/src/usage/usage.rst
+++ b/docs/src/usage/usage.rst
@@ -84,7 +84,7 @@ Starting the gRPC Listener
 
    .. code-block:: bash
 
-                  build/sbt test:assembly # create a fat jar with all necessary dependencies
+                  build/sbt assembly # create a fat jar with all necessary dependencies
 
                   spark-submit --class edu.berkeley.cs.rise.opaque.rpc.Listener  \
                      <Spark configuration parameters> \

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("com.github.alonsodomin" % "sbt-spark" % "0.6.0")
 
 addSbtPlugin("ch.jodersky" % "sbt-jni" % "1.4.1")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")


### PR DESCRIPTION
This PR enables running the listener with `build/sbt assembly` instead of `build/sbt test:assembly` (basically submitting a jar to Spark that does not contain unnecessary test files). It also renames the shade rule to better reflect what we are doing (changing references to Guava classes for non-Spark dependencies to use a newer version). We actually do not have to selectively pick the libraries this should be done for, since Spark is marked as "Provided" automatically by the `sbt-spark` plugin, meaning it is not included in the fat jar created by `build/sbt assembly`.