### PR TITLE
New log4j.properties not triggering warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,14 +63,10 @@ test in Test := {
 
 testOptions in Test += Tests.Argument("-oF")
 
-lazy val commonJavaOptions = Seq(
-  "-Xmx2048m",
-  "-XX:ReservedCodeCacheSize=384m",
-  "-Dspark.master=local[*]",
-  "-Dlog4j.configuration=log4j.properties"
-)
+lazy val commonJavaOptions =
+  Seq("-Xmx2048m", "-XX:ReservedCodeCacheSize=384m", "-Dlog4j.configuration=log4j.properties")
 javaOptions in Test ++= commonJavaOptions
-javaOptions in run ++= commonJavaOptions
+javaOptions in run ++= commonJavaOptions ++ Seq("-Dspark.master=local[*]")
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -62,12 +62,15 @@ test in Test := {
 }
 
 testOptions in Test += Tests.Argument("-oF")
-javaOptions in Test ++= Seq("-Xmx2048m", "-XX:ReservedCodeCacheSize=384m")
-javaOptions in run ++= Seq(
+
+lazy val commonJavaOptions = Seq(
   "-Xmx2048m",
   "-XX:ReservedCodeCacheSize=384m",
-  "-Dspark.master=local[*]"
+  "-Dspark.master=local[*]",
+  "-Dlog4j.configuration=log4j.properties"
 )
+javaOptions in Test ++= commonJavaOptions
+javaOptions in run ++= commonJavaOptions
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,4 +1,23 @@
-log4j.logger.org.apache.spark=WARN
-log4j.logger.org.apache.hadoop=WARN
-log4j.logger.org.apache.spark.executor.Executor=ERROR
-log4j.logger.org.apache.spark.scheduler.TaskSetManager=ERROR
+# Set everything to be logged to the console
+log4j.rootCategory=WARN, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Set the default spark-shell log level to WARN. When running the spark-shell, the
+# log level for this class is used to overwrite the root logger's log level, so that
+# the user can have different defaults for the shell and regular Spark apps.
+log4j.logger.org.apache.spark.repl.Main=WARN
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.sparkproject.jetty=WARN
+log4j.logger.org.sparkproject.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Set everything to be logged to the console
-log4j.rootCategory=WARN, console
+log4j.rootCategory=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
@@ -17,6 +17,9 @@ log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
 log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
 log4j.logger.org.apache.parquet=ERROR
 log4j.logger.parquet=ERROR
+log4j.logger.org.apache.hadoop=WARN
+log4j.logger.org.apache.spark.executor.Executor=ERROR
+log4j.logger.org.apache.spark.scheduler.TaskSetManager=ERROR
 
 # SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
 log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL


### PR DESCRIPTION
Spark is printing these warnings with `Console.err.println` resulting in scary "[error]" messages when running `build/sbt run` -- this PR is a proper fix that removes the cause behind the warnings entirely.