### PR TITLE
Update Installation Doc

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,4 +1,4 @@
-# Install OpenEnclave 0.9.0
+# Install OpenEnclave 0.12.0
 echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
 echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
@@ -22,7 +22,8 @@ tar xvf spark-3.1.1*
 sudo mkdir /opt/spark
 sudo mv spark-3.1.1*/* /opt/spark
 rm -rf spark-3.1.1*
-sudo chmod -R +wx /opt/spark/work
+sudo mkdir /opt/spark/work
+sudo chmod -R a+wx /opt/spark/work
 
 # Set Spark environment variables
 export SPARK_HOME=/opt/spark

--- a/docs/src/install/install.rst
+++ b/docs/src/install/install.rst
@@ -21,7 +21,8 @@ After downloading the Opaque codebase, build and test it as follows.
                    sudo mkdir /opt/spark
                    sudo mv spark-3.1.1*/* /opt/spark
                    rm -rf spark-3.1.1*
-                   sudo chmod -R +wx /opt/spark/work # may not be needed, depends on where Spark is installed
+                   sudo mkdir /opt/spark/work
+                   sudo chmod -R a+wx /opt/spark/work
 
                    # Set Spark environment variables in ~/.bashrc
                    echo "" >> ~/.bashrc
@@ -30,27 +31,26 @@ After downloading the Opaque codebase, build and test it as follows.
                    echo "export PATH=$PATH:/opt/spark/bin:/opt/spark/sbin" >> ~/.bashrc
                    source ~/.bashrc
 
-2. On the master, generate a keypair using OpenSSL for remote attestation.
-
-   .. code-block:: bash
-               
-                   openssl genrsa -out private_key.pem -3 3072
-
-3. Change into the Opaque root directory and edit Opaque's environment variables in ``opaqueenv`` if desired. Export Opaque and OpenEnclave environment variables via
+2. Change into the Opaque root directory and edit Opaque's environment variables in ``opaqueenv`` if desired. Export Opaque and OpenEnclave environment variables via
 
    .. code-block:: bash
                    
                    source opaqueenv
                    source /opt/openenclave/share/openenclave/openenclaverc
-
    By default, Opaque runs in hardware mode (environment variable ``MODE=HARDWARE``).
    If you do not have a machine with a hardware enclave but still wish to test out Opaque's functionality locally, then set ``export MODE=SIMULATE``.
+
+3. On the master, generate a keypair in the Opaque root directory using OpenSSL for remote attestation.
+
+   .. code-block:: bash
+
+                   cd ${OPAQUE_HOME}
+                   openssl genrsa -out private_key.pem -3 3072
 
 4. Run the Opaque tests:
 
    .. code-block:: bash
                 
-                   cd ${OPAQUE_HOME}
                    build/sbt test
 
 5. Alternatively, to generate coverage reports:

--- a/docs/src/install/install.rst
+++ b/docs/src/install/install.rst
@@ -37,6 +37,7 @@ After downloading the Opaque codebase, build and test it as follows.
                    
                    source opaqueenv
                    source /opt/openenclave/share/openenclave/openenclaverc
+
    By default, Opaque runs in hardware mode (environment variable ``MODE=HARDWARE``).
    If you do not have a machine with a hardware enclave but still wish to test out Opaque's functionality locally, then set ``export MODE=SIMULATE``.
 


### PR DESCRIPTION
This PR proposes some tweaks to the installation docs.

1. Installing Spark as specified doesn't create the `/opt/spark/work` directory so the user needs to specify this. Additionally, `sudo chmod -R +wx /opt/spark/work` makes this directory only writeable by root which means you have to run everything as sudo (which I don't believe is intended behavior). 
2. The docs should specify that `private_key.pem` needs to be in the Opaque root directory. I moved the order of a few instructions around to make more logical sense and to resolve this.