### PR TITLE
Change apt to apt-get in build scripts

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,4 +1,4 @@
-# Install OpenEnclave 0.9.0
+# Install OpenEnclave 0.12.0
 echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
 echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
@@ -6,11 +6,11 @@ wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
 wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
-sudo apt update
-sudo apt -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.12.0
+sudo apt-get update
+sudo apt-get -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave=0.12.0
 
 # Install Opaque Dependencies
-sudo apt -y install wget build-essential openjdk-8-jdk python libssl-dev
+sudo apt-get -y install wget build-essential openjdk-8-jdk python libssl-dev
 
 # Install a newer version of CMake (3.15)
 wget https://github.com/Kitware/CMake/releases/download/v3.15.6/cmake-3.15.6-Linux-x86_64.sh


### PR DESCRIPTION
Using apt results in an unstable CLI interface warning that may break the pipeline. See https://serverfault.com/questions/958003/how-to-disable-warning-apt-does-not-have-a-stable-cli-interface for more details.