### PR TITLE
Explicitly set hostname to be localhost in build.sh

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -28,6 +28,9 @@ sudo chmod -R +wx /opt/spark/work
 export SPARK_HOME=/opt/spark
 export PATH=$PATH:/opt/spark/bin:/opt/spark/sbin
 
+# Set hostname to be localhost, since only running build/sbt test
+sudo hostname -s 127.0.0.1
+
 # Generate keypair for attestation
 openssl genrsa -out ./private_key.pem -3 3072
 


### PR DESCRIPTION
Fixes transient error `java.net.BindException: Cannot assign requested address: Service 'sparkDriver' failed after 16 retries (on a random free port)! Consider explicitly setting the appropriate binding address for the service 'sparkDriver' (for example spark.driver.bindAddress for SparkDriver) to the correct binding address.` See https://stackoverflow.com/questions/44914144/error-sparkcontext-error-initializing-sparkcontext-java-net-bindexception-can/44916516 for details.

This can be done in the build because we're only running `build/sbt test`, not starting a Spark cluster through `spark-shell` or `spark-submit`.