### PR TITLE
Grpc ServiceProvider

### DIFF
--- a/gen_pubkey_header.sh
+++ b/gen_pubkey_header.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+destfile="$1"
+pubkey_file="$2"
+
+cat > "$destfile" << EOF
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+EOF
+
+printf 'static const char OTHER_ENCLAVE_PUBLIC_KEY[] =' >> "$destfile"
+while IFS="" read -r p || [ -n "$p" ]
+do
+    # Sometimes openssl can insert carriage returns into the PEM files. Let's remove those!
+    CR=$(printf "\r")
+    p=$(echo "$p" | tr -d "$CR")
+    printf '\n    \"%s\\n\"' "$p" >> "$destfile"
+done < "$pubkey_file"
+printf ';\n' >> "$destfile"
+
+cat >> "$destfile" << EOF
+
+EOF

--- a/src/enclave/Common/common.h
+++ b/src/enclave/Common/common.h
@@ -84,6 +84,8 @@ typedef struct oe_report_msg_t {
 
 typedef struct oe_shared_key_msg_t {
   uint8_t shared_key_ciphertext[OE_SHARED_KEY_CIPHERTEXT_SIZE];
+  size_t user_cert_len;
+  char user_cert[2000];
 } oe_shared_key_msg_t;
 
 #endif // COMMON_H

--- a/src/enclave/ServiceProvider/CMakeLists.txt
+++ b/src/enclave/ServiceProvider/CMakeLists.txt
@@ -16,6 +16,8 @@ link_directories(${OE_LIBDIR})
 link_directories(${OE_LIBDIR}/openenclave/enclave)
 include_directories(${OE_INCLUDEDIR})
 include_directories(${OE_INCLUDEDIR}/openenclave/3rdparty)
+include_directories(${CMAKE_SOURCE_DIR}/../Common)
+include_directories(${CMAKE_SOURCE_DIR}/../Include)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -Wno-attributes")
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}")
@@ -25,6 +27,9 @@ add_library(ra_jni SHARED ${SOURCES})
 if ("$ENV{MODE}" STREQUAL "SIMULATE")
   target_compile_definitions(ra_jni PUBLIC -DSIMULATE)
 endif()
+
+set(OE_MIN_VERSION 0.12.0)
+find_package(OpenEnclave ${OE_MIN_VERSION} CONFIG REQUIRED)
 
 find_library(CRYPTO_LIB crypto)
 find_library(SSL_LIB ssl)

--- a/src/enclave/ServiceProvider/SP.h
+++ b/src/enclave/ServiceProvider/SP.h
@@ -1,4 +1,8 @@
 #include <jni.h>
+#include <string>
+#include <iostream>
+
+#include "ServiceProvider.h"
 
 #ifndef _Included_SP
 #define _Included_SP
@@ -17,6 +21,44 @@ Java_edu_berkeley_cs_rise_opaque_execution_SP_ProcessEnclaveReport(JNIEnv *, job
 JNIEXPORT jbyteArray JNICALL Java_edu_berkeley_cs_rise_opaque_execution_SP_SPProcMsg3(JNIEnv *,
                                                                                       jobject,
                                                                                       jbyteArray);
+
+JNIEXPORT jbyteArray JNICALL
+Java_edu_berkeley_cs_rise_opaque_execution_SP_Decrypt(JNIEnv *, jobject, jstring);
+
+// Python wrapper functions
+ServiceProvider* sp_new(){ 
+  const std::string id("client");
+  return new ServiceProvider(id, false, false);
+}
+
+void
+sp_init_wrapper(ServiceProvider * sp, uint8_t * provided_cert, size_t cert_len) {
+  sp->init_wrapper(provided_cert, cert_len);
+}
+
+void
+sp_process_enclave_report(ServiceProvider * sp, uint8_t * report, size_t * report_len, uint8_t ** ret_val, size_t * ret_len) { 
+
+//  std::cout << "Enter wrapper function" << std::endl;
+  sp->process_enclave_report_python_wrapper(report, report_len, ret_val, ret_len);
+//  std::cout << "Exit wrapper function" << std::endl;
+}
+
+void
+sp_decrypt(ServiceProvider * sp, char * cipher, size_t * cipher_len, uint8_t ** plain, size_t * plain_len) {
+
+  sp->aes_gcm_decrypt(cipher, cipher_len, plain, plain_len);
+}
+
+void
+sp_free_array(ServiceProvider *sp, uint8_t ** array) {
+  sp->free_array(array);
+}
+
+void
+sp_clean(ServiceProvider *sp) {
+  sp->clean_up();
+}
 
 #ifdef __cplusplus
 }

--- a/src/enclave/ServiceProvider/ServiceProvider.cpp
+++ b/src/enclave/ServiceProvider/ServiceProvider.cpp
@@ -12,11 +12,15 @@
 #include "ias_ra.h"
 #include "iasrequest.h"
 #include "json.hpp"
+#include "sp_crypto.h"
 
 #include <openenclave/host.h>
 #include <openenclave/host_verify.h>
 
 #include "ServiceProvider.h"
+
+// For debugging
+#include <iomanip>
 
 // Your 16-byte Service Provider ID (SPID), assigned by Intel.
 const uint8_t spid[] = {0xA4, 0x62, 0x09, 0x2E, 0x1B, 0x59, 0x26, 0xDF,
@@ -50,6 +54,87 @@ void lc_check(lc_status_t ret) {
 
     throw std::runtime_error(std::string("Service provider crypto failure: ") + error);
   }
+}
+
+// TODO: Create shared key by reading from file. Currently key is hard-coded
+void ServiceProvider::init_wrapper(uint8_t * provided_cert, size_t cert_len) {
+  // Initialize key
+//  uint8_t * new_key = (uint8_t *) calloc(LC_AESGCM_KEY_SIZE, sizeof(uint8_t));
+  const char *new_key = (const char *)"01234567890123456789012345678901";
+
+  if (strlen(new_key) * sizeof(char) != LC_AESGCM_KEY_SIZE) {
+    std::cout << "size of provided key: " << sizeof(new_key) << std::endl;
+    throw std::runtime_error("new key not right size");
+  }
+
+  memcpy(this->shared_key, new_key, LC_AESGCM_KEY_SIZE);
+
+//  free(new_key);
+
+  // Initialize user certificate
+  char * cert = (char *) malloc(cert_len * sizeof(char));
+  memcpy(cert, provided_cert, cert_len);
+  this->user_cert = cert;
+}
+
+void
+ServiceProvider::process_enclave_report_python_wrapper(uint8_t * report, size_t * report_len, uint8_t ** ret_val, size_t * ret_len) {
+
+  size_t report_size = *report_len;
+  uint8_t* report_bytes = new uint8_t[report_size];
+  memcpy(report_bytes, report, report_size);
+  oe_report_msg_t *report_msg = reinterpret_cast<oe_report_msg_t *>(report_bytes);
+
+  uint32_t shared_key_msg_size = 0;
+  std::unique_ptr<oe_shared_key_msg_t> shared_key_msg;
+  try {
+    shared_key_msg = this->process_enclave_report(report_msg, &shared_key_msg_size);
+  } catch (const std::runtime_error &e) {
+    throw std::runtime_error("Failed to process report.");
+  }
+  uint8_t * ret_msg = (uint8_t *) malloc(shared_key_msg_size);
+
+  memcpy(ret_msg, reinterpret_cast<uint8_t *>(shared_key_msg.get()), shared_key_msg_size);
+
+  *ret_len = shared_key_msg_size;
+  *ret_val = ret_msg;
+
+}
+
+void ServiceProvider::aes_gcm_decrypt(char * cipher, size_t * cipher_len, uint8_t ** plain, size_t * plain_len) {
+
+  (void) cipher_len;
+
+  size_t sz = 0;
+  char * cipher_decode = base64_decode(cipher, &sz);
+
+  // Obtain the plaintext len
+  size_t plaintext_length = sz - (LC_AESGCM_IV_SIZE + LC_AESGCM_MAC_SIZE);
+  unsigned char * plaintext_msg = (unsigned char *) malloc(plaintext_length);
+
+  unsigned char *iv_ptr = (unsigned char *)cipher_decode;
+  unsigned char *ciphertext_ptr = (unsigned char *)(cipher_decode + LC_AESGCM_IV_SIZE);
+  unsigned char *mac_ptr = (unsigned char *) (cipher_decode + LC_AESGCM_IV_SIZE + plaintext_length);
+
+  int ret = decrypt(ciphertext_ptr, sz - LC_AESGCM_IV_SIZE - LC_AESGCM_MAC_SIZE,
+                this->shared_key, iv_ptr,
+                plaintext_msg, mac_ptr);
+  if (ret == 0) {
+    throw std::runtime_error("Failed to decrypt");
+  }
+
+  free(cipher_decode);
+
+  *plain_len = plaintext_length;
+  *plain = plaintext_msg;
+}
+
+void ServiceProvider::clean_up() {
+  free(this->user_cert);
+}
+
+void ServiceProvider::free_array(uint8_t ** array) {
+  free(*array);
 }
 
 void ServiceProvider::load_private_key(const std::string &filename) {
@@ -117,6 +202,14 @@ void ServiceProvider::load_private_key(const std::string &filename) {
 
 void ServiceProvider::set_shared_key(const uint8_t *shared_key) {
   memcpy(this->shared_key, shared_key, LC_AESGCM_KEY_SIZE);
+}
+
+void ServiceProvider::set_user_cert(const std::string user_cert) {
+  const char * cert = user_cert.c_str();
+  uint32_t cert_len = strlen(cert);
+
+  this->user_cert = (char *) malloc(cert_len * sizeof(char));
+  memcpy(this->user_cert, cert, cert_len);
 }
 
 void ServiceProvider::export_public_key_code(const std::string &filename) {
@@ -235,15 +328,24 @@ std::unique_ptr<oe_shared_key_msg_t>
 ServiceProvider::process_enclave_report(oe_report_msg_t *report_msg,
                                         uint32_t *shared_key_msg_size) {
 
+//  std::cout << "Enter process_enclave_report" << std::endl;
+
+  if (this->user_cert == NULL) {
+    throw std::runtime_error("SP not initialized with user cert");
+  }
+
   int ret;
   unsigned char encrypted_sharedkey[OE_SHARED_KEY_CIPHERTEXT_SIZE];
   size_t encrypted_sharedkey_size = sizeof(encrypted_sharedkey);
+
   std::unique_ptr<oe_shared_key_msg_t> shared_key_msg(new oe_shared_key_msg_t);
 
+//  std::cout << "Before get public key" << std::endl;
   EVP_PKEY *pkey = buffer_to_public_key((char *)report_msg->public_key, -1);
   if (pkey == nullptr) {
     throw std::runtime_error("buffer_to_public_key failed.");
   }
+//  std::cout << "After get public key" << std::endl;
 
 #ifdef SIMULATE
   std::cerr << "Not running remote attestation because executing in simulation mode" << std::endl;
@@ -254,11 +356,13 @@ ServiceProvider::process_enclave_report(oe_report_msg_t *report_msg,
   oe_result_t result = OE_FAILURE;
   uint8_t sha256[32];
 
+//  std::cout << "Before oe verify" << std::endl;
   result = oe_verify_remote_report(report_msg->report, report_msg->report_size, NULL, 0,
                                    &parsed_report);
   if (result != OE_OK) {
     throw std::runtime_error(std::string("oe_verify_remote_report: ") + oe_result_str(result));
   }
+//  std::cout << "After oe verify" << std::endl;
 
   // mrsigner verification
   // 2) validate the enclave identity's signed_id is the hash of the public
@@ -267,6 +371,7 @@ ServiceProvider::process_enclave_report(oe_report_msg_t *report_msg,
 
   // 2a) Read in the public key as a string
 
+//  std::cout << "Before read public key from outside" << std::endl;
   std::string public_key_file = std::string(std::getenv("OPAQUE_HOME"));
   public_key_file.append("/public_key.pub");
 
@@ -281,14 +386,19 @@ ServiceProvider::process_enclave_report(oe_report_msg_t *report_msg,
   public_key.assign((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
   public_key.replace(public_key_size, 1, "\0");
 
+//  std::cout << "After read public key from outside" << std::endl;
+
+//  std::cout << "Before verify mrsigner" << std::endl;
   if (!verify_mrsigner((char *)public_key.c_str(), public_key.size(),
                        parsed_report.identity.signer_id,
                        sizeof(parsed_report.identity.signer_id))) {
     throw std::runtime_error(std::string("failed: mrsigner not equal!"));
   }
+//  std::cout << "After verify mrsigner" << std::endl;
 
   // TODO missing the hash verification step
 
+//  std::cout << "Before rest of verification" << std::endl;
   // check the enclave's product id and security version
   if (parsed_report.identity.product_id[0] != 1) {
     throw std::runtime_error(std::string("identity.product_id checking failed."));
@@ -308,22 +418,31 @@ ServiceProvider::process_enclave_report(oe_report_msg_t *report_msg,
   if (memcmp(parsed_report.report_data, sha256, sizeof(sha256)) != 0) {
     throw std::runtime_error(std::string("SHA256 mismatch."));
   }
+//  std::cout << "After rest of verification" << std::endl;
 
 #endif
 
   // Encrypt shared key
   ret = public_encrypt(pkey, this->shared_key, LC_AESGCM_KEY_SIZE, encrypted_sharedkey,
                        &encrypted_sharedkey_size);
+
   if (ret == 0) {
     throw std::runtime_error(std::string("public_encrypt: buffer too small"));
   } else if (ret < 0) {
     throw std::runtime_error(std::string("public_encrypt failed"));
   }
 
+//  std::cout << "Before prepare shared_key_msg" << std::endl;
   // Prepare shared_key_msg
   memcpy_s(shared_key_msg->shared_key_ciphertext, OE_SHARED_KEY_CIPHERTEXT_SIZE,
            encrypted_sharedkey, encrypted_sharedkey_size);
+
+  size_t cert_len = strlen(this->user_cert) + 1;
+  memcpy_s(shared_key_msg->user_cert, cert_len, this->user_cert, cert_len);
+  shared_key_msg->user_cert_len = cert_len;
+
   *shared_key_msg_size = sizeof(oe_shared_key_msg_t);
+//  std::cout << "After prepare shared_key_msg" << std::endl;
 
   // clean up
   EVP_PKEY_free(pkey);

--- a/src/enclave/ServiceProvider/sp_crypto.h
+++ b/src/enclave/ServiceProvider/sp_crypto.h
@@ -173,16 +173,28 @@ EC_KEY *get_priv_key(lc_ec256_private_t *p_private);
  *buffer should be >= src_len. lc_aes_gcm_128bit_tag_t *p_out_mac - Pointer to
  *MAC generated from encryption process NOTE: Wrapper is responsible for
  *confirming decryption tag matches encryption tag */
-LC_LIBCRYPTO_API lc_status_t WARN_UNUSED lc_rijndael128GCM_encrypt(
-    const lc_aes_gcm_128bit_key_t *p_key, const uint8_t *p_src, uint32_t src_len, uint8_t *p_dst,
-    const uint8_t *p_iv, uint32_t iv_len, const uint8_t *p_aad, uint32_t aad_len,
-    lc_aes_gcm_128bit_tag_t *p_out_mac);
+//LC_LIBCRYPTO_API lc_status_t WARN_UNUSED lc_rijndael128GCM_encrypt(
+//    const lc_aes_gcm_128bit_key_t *p_key, const uint8_t *p_src, uint32_t src_len, uint8_t *p_dst,
+//    const uint8_t *p_iv, uint32_t iv_len, const uint8_t *p_aad, uint32_t aad_len,
+//    lc_aes_gcm_128bit_tag_t *p_out_mac);
+
+LC_LIBCRYPTO_API int WARN_UNUSED lc_rijndael128GCM_encrypt(unsigned char *plaintext, int plaintext_len,
+                unsigned char *aad, int aad_len,
+                unsigned char *key,
+                unsigned char *iv, int iv_len,
+                unsigned char *ciphertext,
+                unsigned char *tag);
 
 lc_status_t WARN_UNUSED lc_rijndael128GCM_decrypt(unsigned char *ciphertext, int ciphertext_len,
                                                   unsigned char *aad, int aad_len,
                                                   unsigned char *tag, unsigned char *key,
                                                   unsigned char *iv, unsigned char *plaintext)
     __attribute__((warn_unused_result));
+
+int encrypt(unsigned char *plaintext, int plaintext_len, unsigned char *key,
+            unsigned char *iv, unsigned char *ciphertext, unsigned char *tag);
+int decrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *key,
+            unsigned char *iv, unsigned char *plaintext, unsigned char *tag);
 
 /* Message Authentication - Rijndael 128 CMAC
  * Parameters:

--- a/src/main/scala/edu/berkeley/cs/rise/opaque/execution/SP.scala
+++ b/src/main/scala/edu/berkeley/cs/rise/opaque/execution/SP.scala
@@ -22,8 +22,11 @@ import ch.jodersky.jni.nativeLoader
 @nativeLoader("ra_jni")
 class SP extends java.io.Serializable {
   // Remote attestation, master side
-  @native def Init(sharedKey: Array[Byte], intelCert: String): Unit
+  @native def Init(sharedKey: Array[Byte], userCert: String): Unit
   @native def SPProcMsg0(msg0Input: Array[Byte]): Unit
   @native def ProcessEnclaveReport(msg1Input: Array[Byte]): Array[Byte]
   @native def SPProcMsg3(msg3Input: Array[Byte]): Array[Byte]
+
+  // Decryption, client side
+  @native def Decrypt(cipher: String): Array[Byte]
 }


### PR DESCRIPTION
This PR updates the ServiceProvider with a new AES_GCM decryption function and adds a user_cert to the shared_key_msg.
It also includes various wrapper functions that can be called by external python programs using ctypes. Finally, there is an updated CMakeLists.txt to create the necessary .so file for the aforementioned wrapper functions.