### PR TITLE
TPCH testing for grpc

### DIFF
--- a/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueSuiteBase.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/OpaqueSuiteBase.scala
@@ -18,9 +18,17 @@
 package edu.berkeley.cs.rise.opaque
 
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
+import org.apache.spark.unsafe.types.UTF8String
+
+import java.sql.Date
+import java.util.concurrent.TimeUnit
 
 import org.scalatest.BeforeAndAfterAll
+import org.scalactic.Equality
 
 trait OpaqueSuiteBase extends OpaqueFunSuite with BeforeAndAfterAll with SQLTestData {
 
@@ -35,6 +43,61 @@ trait OpaqueSuiteBase extends OpaqueFunSuite with BeforeAndAfterAll with SQLTest
     Utils.cleanup(spark)
   }
 
+  // TODO: Override checkAnswer for new functionality. Uncomment after merging with 
+  // key-gen, re-encryption, sp, and python pull requests
+//  override def checkAnswer[A: Equality](
+//       ignore: Boolean = false,
+//       isOrdered: Boolean = false,
+//       verbose: Boolean = false,
+//       printPlan: Boolean = false,
+//       shouldLogOperators: Boolean = false
+//   )(f: SecurityLevel => A): Unit = {
+//     if (ignore) {
+//       return
+//     }
+//
+//     Utils.setOperatorLoggingLevel(shouldLogOperators)
+//     val (insecure, encrypted) = (f(Insecure), f(Encrypted))
+//     (insecure, encrypted) match {
+//       case (insecure: DataFrame, encrypted: DataFrame) =>
+//         val insecureSeq = insecure.collect
+//         val schema = insecure.schema
+//
+//         encrypted.collect
+//         val encryptedRows = SPHelper.obtainRows(encrypted) 
+//         val encryptedRows2 = encryptedRows.map(x => prepareRowWithSchema(x, schema))
+//         val encryptedDF = spark.createDataFrame(
+//                                spark.sparkContext.makeRDD(encryptedRows2, numPartitions),
+//                                schema)
+//
+//         val encryptedSeq = encryptedDF.collect
+//
+//         // Unable to test any compound filtering functionality as results returned from any
+//         // operation are not returned immediately but stored in file on disk.
+//         // See benchmark/KMeans.scala and benchmark/LogisticRegression.scala for example
+//         val equal = insecureSeq.toSet == encryptedSeq.toSet
+// //          if (isOrdered) insecureSeq === encryptedSeq
+// //          else insecureSeq.toSet === encryptedSeq.toSet
+//         if (!equal) {
+//           if (printPlan) {
+//             println("**************** Spark Plan ****************")
+//             insecure.explain()
+//             println("**************** Opaque Plan ****************")
+//             encrypted.explain()
+//           }
+//           println(genError(insecureSeq, encryptedSeq, isOrdered, verbose))
+//         }
+//         assert(equal)
+//       case (insecure: Array[Array[Double]], encrypted: Array[Array[Double]]) =>
+//         for ((x, y) <- insecure.zip(encrypted)) {
+//
+//           assert(x === y)
+//         }
+//       case _ =>
+//         assert(insecure === encrypted)
+//     }
+//   }
+
   def makeDF[A <: Product: scala.reflect.ClassTag: scala.reflect.runtime.universe.TypeTag](
       data: Seq[A],
       sl: SecurityLevel,
@@ -46,4 +109,40 @@ trait OpaqueSuiteBase extends OpaqueFunSuite with BeforeAndAfterAll with SQLTest
         .toDF(columnNames: _*)
     )
   }
+
+  // Using a schema, convert the row into the relevant datatypes
+  // Only certain types are implemented currently. Add as needed
+  private def prepareRowWithSchema(row: Row, schema: StructType): Row = {
+     val fields = schema.fields
+
+     if (row == null) {
+       println("null row")
+       return null
+     }
+
+     assert(row.length == fields.size)
+
+     Row.fromSeq(for (i <- 0 until row.length) yield {
+           val rowValue = row(i)
+           val fieldDataType = fields(i).dataType
+           val converted = fieldDataType match {
+             case ArrayType(_,_) => rowValue
+             case BinaryType => rowValue 
+             case BooleanType => rowValue 
+             case CalendarIntervalType => rowValue
+
+             // TPCH dates are calculated in days for some reason
+             case DateType => new Date(TimeUnit.DAYS.toMillis(rowValue.asInstanceOf[Integer].toLong))
+             case MapType(_,_,_) => rowValue 
+             case NullType => rowValue
+ //            case IntegerType => rowValue.asInstanceOf[Integer]
+ //            case DoubleType => rowValue.asInstanceOf[Double]
+             case StringType => rowValue.asInstanceOf[UTF8String].toString()
+             case StructType(_) => rowValue
+             case TimestampType => rowValue
+             case _ => rowValue
+           }
+           converted
+         })
+   }
 }

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/SPHelper.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/SPHelper.scala
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.rise.opaque
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+
+import java.util.Base64
+
+import java.nio.ByteBuffer
+
+import edu.berkeley.cs.rise.opaque.execution.SP
+
+object SPHelper {
+
+  val sp = new SP()
+
+  // Create a SP for decryption
+  // TODO: Change hard-coded path for user_cert
+  val userCert = scala.io.Source.fromFile("/home/opaque/opaque/user1.crt").mkString
+
+  // Change empty key to key used in RA.initRA to allow for decryption
+  final val GCM_KEY_LENGTH = 32
+  val sharedKey: Array[Byte] = Array.fill[Byte](GCM_KEY_LENGTH)(0)
+  sp.Init(sharedKey, userCert)
+
+  def convertGenericArrayData(rowData: Row, index: Int): Row = {
+
+    val data = rowData(index).asInstanceOf[GenericArrayData]
+
+    val dataArray = new Array[Double](data.numElements)
+    for (i <- 0 until dataArray.size) {
+      dataArray(i) = data.getDouble(i)
+    }
+    return Row(dataArray)
+  }
+
+  def convertGenericArrayDataKMeans(rowData: Row, index: Int): Row = {
+
+    val data = rowData(index).asInstanceOf[GenericArrayData]
+
+    val dataArray = new Array[Double](data.numElements)
+    for (i <- 0 until dataArray.size) {
+      dataArray(i) = data.getDouble(i)
+    }
+
+    val dataTwo = rowData(1).asInstanceOf[GenericArrayData]
+
+    val dataArrayTwo = new Array[Double](dataTwo.numElements)
+    for (i <- 0 until dataArrayTwo.size) {
+      dataArrayTwo(i) = dataTwo.getDouble(i)
+    }
+
+    return Row(dataArray, dataArrayTwo, rowData(2))
+  }
+
+  def obtainRows(df: DataFrame) : Seq[Row] = {
+
+    // Hardcoded user1 for driver
+    val ciphers = Utils.postVerifyAndReturn(df, "user1")
+
+    val internalRow = (for (cipher <- ciphers) yield {
+
+      val plain = sp.Decrypt(Base64.getEncoder().encodeToString(cipher))
+      val rows = tuix.Rows.getRootAsRows(ByteBuffer.wrap(plain))
+
+      for (j <- 0 until rows.rowsLength) yield {
+        val row = rows.rows(j)
+        assert(!row.isDummy)
+        Row.fromSeq(for (k <- 0 until row.fieldValuesLength) yield {
+          val field: Any =
+            if (!row.fieldValues(k).isNull()) {
+              Utils.flatbuffersExtractFieldValue(row.fieldValues(k))
+            } else {
+              null
+            }
+          field
+        })
+      }
+    }).flatten
+
+    return internalRow
+  }
+}

--- a/src/test/scala/edu/berkeley/cs/rise/opaque/grpc/gRPCSuite.scala
+++ b/src/test/scala/edu/berkeley/cs/rise/opaque/grpc/gRPCSuite.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.rise.opaque.grpc
+
+import edu.berkeley.cs.rise.opaque.OpaqueSuiteBase
+import edu.berkeley.cs.rise.opaque.MultiplePartitionSparkSession
+import edu.berkeley.cs.rise.opaque.SinglePartitionSparkSession
+
+import org.apache.spark.sql.SparkSession
+
+import edu.berkeley.cs.rise.opaque.Utils
+import edu.berkeley.cs.rise.opaque.tpch.TPCH
+
+import org.scalatest.BeforeAndAfterAll
+
+trait gRPCSuite extends OpaqueSuiteBase with BeforeAndAfterAll { self =>
+
+  // TODO: Hardcoded paths to program, jar, and master ip
+  val listenerSub = os.proc("python3", "src/main/grpc/OpaqueRPCListener.py", "-j", 
+      "/home/opaque/opaque/target/scala-2.12/opaque_2.12-0.1.jar", "-m", "spark://eric:7077").spawn()
+  
+  // Placeholder program. To be changed later in beforeAll
+  var clientSub = os.proc("python3", "-u", "-c", "print(0)").spawn()
+
+  override def beforeAll(): Unit = {
+    // Initialize client here as listener takes time to start
+    Thread.sleep(15000)
+    clientSub = os.proc("python3", "src/main/grpc/OpaqueClient.py").spawn()
+
+    // Necessary inputs and imports
+    clientSub.stdin.writeLine("import edu.berkeley.cs.rise.opaque.tpch")
+    clientSub.stdin.flush()
+    println("first: " + clientSub.stdout.readLine())    
+    println("second: " + clientSub.stdout.readLine())
+
+    clientSub.stdin.writeLine("import edu.berkeley.cs.rise.opaque.{SecurityLevel, Insecure, Encrypted}")
+    clientSub.stdin.flush()
+    println("first: " + clientSub.stdout.readLine())
+    println("second: " + clientSub.stdout.readLine())
+
+    clientSub.stdin.writeLine("""def size = "sf_001" """)
+    clientSub.stdin.flush()
+    println("first: " + clientSub.stdout.readLine())
+    println("second: " + clientSub.stdout.readLine())
+
+    clientSub.stdin.writeLine("def numPartitions = 3")
+    clientSub.stdin.flush()
+    println("first: " + clientSub.stdout.readLine())
+    println("second: " + clientSub.stdout.readLine())
+ 
+    clientSub.stdin.writeLine("""def tpch = new edu.berkeley.cs.rise.opaque.tpch.TPCH(spark.sqlContext, size, "file://")""")
+    clientSub.stdin.flush()
+    println("first: " + clientSub.stdout.readLine())
+    println("second: " + clientSub.stdout.readLine())
+  }
+
+  override def afterAll(): Unit = {
+    if (clientSub.isAlive()) {clientSub.destroy()}
+    if (listenerSub.isAlive()) {listenerSub.destroy()}
+  }
+
+  def runTests() = {
+    for (queryNum <- TPCH.supportedQueries) {
+      val testStr = s"TPC-H $queryNum"
+      test(testStr) {
+        val queryStr = s"tpch.query($queryNum, Encrypted, numPartitions).collect"
+        clientSub.stdin.writeLine(queryStr)
+        clientSub.stdin.flush()
+
+        // Wait for completion. 
+        // 1st line is result of format: 'opaque> res#: ...'
+        // 2nd line is new line
+        // Occasionally some other line will pop up, so we check to make sure that doesn't happen
+        var first = clientSub.stdout.readLine()
+        while (first == null || !first.contains("res")) {
+          first = clientSub.stdout.readLine()
+        }
+
+        println("first: " + first)
+        println("second: " + clientSub.stdout.readLine())
+
+        // TODO: Currently no post-verification merged so just runnning it on emptyDataFrame
+        clientSub.stdin.writeLine("""edu.berkeley.cs.rise.opaque.Utils.postVerifyAndPrint(spark.emptyDataFrame, "user1")""")
+        clientSub.stdin.flush()
+        
+        // Wait for finish
+        clientSub.stdout.readLine()
+        clientSub.stdout.readLine()
+
+        assert(true) 
+      }
+    }
+  }
+}
+
+// Honestly do not need to extend as this suite doesn't use 'spark' or 'numPartitions'.
+// However, it does use FunSuite.
+class MultiPartition_gRPCSuite extends gRPCSuite with MultiplePartitionSparkSession {
+  runTests()
+}


### PR DESCRIPTION
This PR adds testing for TPCH through gRPC python. It also changes the implementation of KMeans and LogisticRgression to be compatible with the re-encryption mechanism (i.e. due to how the re-encryption mechanism works (saving results to file and then reading), tests that require ordering and other compound functionality will fail in this PR. The results must first be read before compound functionality). 

Pull Requests should be merged in the following order: 

Key-get -> gRPC reEncryption -> gRPC ServiceProvider -> gRPC Python Files -> grpc TPCH tests